### PR TITLE
Properly retrieve syscall arguments and add support for filtering on them

### DIFF
--- a/pkg/sensor/kprobe.go
+++ b/pkg/sensor/kprobe.go
@@ -132,9 +132,7 @@ func (f *kprobeFilter) fetchargs() string {
 	return strings.Join(args, " ")
 }
 
-func registerKernelEvents(monitor *perf.EventMonitor, sensor *Sensor, events []*api.KernelFunctionCallFilter) []uint64 {
-	var eventIDs []uint64
-
+func registerKernelEvents(sensor *Sensor, eventMap subscriptionMap, events []*api.KernelFunctionCallFilter) {
 	for _, kef := range events {
 		f := newKprobeFilter(kef)
 		if f == nil {
@@ -143,7 +141,7 @@ func registerKernelEvents(monitor *perf.EventMonitor, sensor *Sensor, events []*
 		}
 
 		f.sensor = sensor
-		eventID, err := monitor.RegisterKprobe(
+		eventID, err := sensor.monitor.RegisterKprobe(
 			f.symbol, f.onReturn, f.fetchargs(),
 			f.decodeKprobe,
 			perf.WithFilter(f.filter))
@@ -159,8 +157,6 @@ func registerKernelEvents(monitor *perf.EventMonitor, sensor *Sensor, events []*
 				f.symbol, loc, f.fetchargs(), err)
 			continue
 		}
-		eventIDs = append(eventIDs, eventID)
+		eventMap[eventID] = &subscription{}
 	}
-
-	return eventIDs
 }


### PR DESCRIPTION
There are two problems with using the tracepoint `raw_syscalls/syscall_enter` as we were previously doing. First, various kernel versions have bugs around how they pass the argument information back to userspace. This was previously worked around in a less-than-elegant fashion. Second, perf_event filters do not support indexing into arrays, so it is not possible to filter based on arguments. Both problems can be solved using a kprobe, but there's a catch: the kprobe will never fire unless the tracepoint is enabled. The way around this is to enable the tracepoint with a filter that will never allow it to add data to the perf_event ringbuffer.

