### PR TITLE
Use a kprobe to track process command-line information

### DIFF
--- a/pkg/sensor/process_info_test.go
+++ b/pkg/sensor/process_info_test.go
@@ -35,10 +35,10 @@ BenchmarkContainerCacheMissParallel-8   	  300000	      5789 ns/op
 */
 
 var values []task = []task{
-	{1, 2, 3, 0x120011, "foo", cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
-	{1, 2, 3, 0x120011, "bar", cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
-	{1, 2, 3, 0x120011, "baz", cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
-	{1, 2, 3, 0x120011, "qux", cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
+	{1, 2, 3, 0x120011, "foo", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
+	{1, 2, 3, 0x120011, "bar", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
+	{1, 2, 3, 0x120011, "baz", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
+	{1, 2, 3, 0x120011, "qux", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
 }
 
 func TestCaches(t *testing.T) {


### PR DESCRIPTION
Use a kprobe in the process info cache to track command-line information when a process execs. This will make the command-line information available later for short-lived processes instead of relying on procfs.

Due to limitations with the kprobe interface, the number of argv elements must be fixed, so the information cached may not always be complete. This number is currently 6, chosen arbitrarily.

