### PR TITLE
Default to https for vendor submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor"]
 	path = vendor
-	url = git@github.com:capsule8/capsule8_vendor.git
+	url = https://github.com/capsule8/capsule8_vendor.git

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TAG=$(shell git describe --tags --abbrev=0 2>/dev/null)
 SHA=$(shell git describe --match=NeVeRmAtCh --always --abbrev=7 --dirty)
 
 ifeq ($(TAG),)
-	VERSION=0.0.0+$(SHA)
+	VERSION=$(SHA)
 else
 	VERSION=$(TAG)+$(SHA)
 endif

--- a/README.md
+++ b/README.md
@@ -21,13 +21,25 @@ For a quick demonstration of the capsule8 sensor's capabilities, start
 up three terminal sessions to run the sensor, example telemetry
 client, and target container as described below.
 
+### Checkout latest code
+
+```
+$ git clone https://github.com/capsule8/capsule8.git
+$ git submodule init && git submodule update
+```
+
+### Build the sensor
+
+```
+$ make
+```
+
 ### Start the sensor
 
 Start the Sensor and listen for API clients on the default local unix
 socket:
 
 ```
-$ make
 $ sudo ./bin/sensor
 I1004 18:55:23.111094    9617 version.go:33] Starting sensor (0.0.0+9b149e4)
 I1004 18:55:23.111736    9617 sensor.go:121] Starting servers...


### PR DESCRIPTION
Make version tag just git SHA on master vs. `v0.0.0-<sha>`.

Update README with instructions to checkout vendor submodule to build.

