### PR TITLE
Add issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+### Is this a bug report or a feature request?
+
+- [ ] bug
+- [ ] feature
+
+### What is the current behavior?
+
+If the current behavior is a bug please provide the steps to reproduce the bug.
+
+### What is the desired behavior?
+
+### What version of Capsule8 are you using?
+
+Version information can be found at the start of all logs as well as from the `/version` endpoint and docker tags and labels in containerized environments. Please include the git sha if possible.
+
+### What kind of environment is this in?
+
+What linux distribution are you running?
+
+If containerized:
+What version of docker is being used?
+What version of kuberenetes is being used?
+
+### For bugs: can you share logs?
+
+### Other Information
+
+Is there anything else that would help us solve your problem?
+Any special information about your environment?
+Links to related issues or information?

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -11,7 +11,9 @@ If the current behavior is a bug please provide the steps to reproduce the bug.
 
 ### What version of Capsule8 are you using?
 
-Version information can be found at the start of all logs as well as from the `/version` endpoint and docker tags and labels in containerized environments. Please include the git sha if possible.
+Version information can be found at the start of all logs as well as from the
+docker label in containerized environments. Please include the git sha if
+possible.
 
 ### What kind of environment is this in?
 
@@ -19,7 +21,7 @@ What linux distribution are you running?
 
 If containerized:
 What version of docker is being used?
-What version of kuberenetes is being used?
+What version of kubernetes is being used?
 
 ### For bugs: can you share logs?
 


### PR DESCRIPTION
In order to best serve people using Capsule8, we want to be able to triage and address all issues opened to this repository. This issue template will give us structured information in order to better address the issues opened.