### PR TITLE
Make the process info cache size configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,10 @@ var Sensor struct {
 
 	// The default buffer length for Go channels used internally
 	ChannelBufferLength int `split_words:"true" default:"1024"`
+
+	// The size of the process info cache. If the system pid_max is greater
+	// than this size, a less performant method of caching will be used.
+	ProcessInfoCacheSize uint `split_words:"true" default:"131072"`
 }
 
 func init() {

--- a/pkg/sensor/process_info_test.go
+++ b/pkg/sensor/process_info_test.go
@@ -34,6 +34,8 @@ BenchmarkContainerCacheMissParallel-8   	  300000	      5789 ns/op
 
 */
 
+const arrayTaskCacheSize = 32768
+
 var values []task = []task{
 	{1, 2, 3, 0x120011, "foo", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
 	{1, 2, 3, 0x120011, "bar", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
@@ -43,7 +45,7 @@ var values []task = []task{
 
 func TestCaches(t *testing.T) {
 
-	arrayCache := newArrayTaskCache()
+	arrayCache := newArrayTaskCache(arrayTaskCacheSize)
 	mapCache := newMapTaskCache()
 
 	for i := 0; i < arrayTaskCacheSize; i++ {
@@ -76,7 +78,7 @@ func TestCaches(t *testing.T) {
 }
 
 func BenchmarkArrayCache(b *testing.B) {
-	cache := newArrayTaskCache()
+	cache := newArrayTaskCache(arrayTaskCacheSize)
 	var tk task
 
 	for i := 0; i < b.N; i++ {
@@ -102,7 +104,7 @@ func BenchmarkMapCache(b *testing.B) {
 }
 
 func BenchmarkArrayCacheParallel(b *testing.B) {
-	cache := newArrayTaskCache()
+	cache := newArrayTaskCache(arrayTaskCacheSize)
 
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0


### PR DESCRIPTION
For performance reasons, the process info cache uses a size threshold. If the system pid_max is <= the process info cache size, an array will without locking will be used; otherwise, a map with locking will be used. The threshold was hard-coded to 32768, which is the default stock kernel value for pid_max. This also increases that default to 131072, which appears to be the default with Ubuntu server installs.

