### PR TITLE
Clean up all golint warnings

### DIFF
--- a/pkg/container/c8dockerclient/client.go
+++ b/pkg/container/c8dockerclient/client.go
@@ -32,8 +32,10 @@ import (
 	"github.com/golang/glog"
 )
 
-//DockerSocketPath is the filesytem path to the docker socket
-const ApiPrefix = "/v1.24"
+// APIPrefix is the prefix used to make Docker requests
+const APIPrefix = "/v1.24"
+
+// DockerSocketPath is the filesytem path to the docker socket
 const DockerSocketPath = "/var/run/docker.sock"
 
 //ClientError encapsulates all errors
@@ -106,7 +108,7 @@ func (client *Client) Request(path, method string, values *url.Values) (resp *ht
 func (client *Client) DockerInfo() (*DockerInfo, error) {
 	var info DockerInfo
 
-	response, err := client.Request(ApiPrefix+"/info", "GET", nil)
+	response, err := client.Request(APIPrefix+"/info", "GET", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +130,7 @@ func (client *Client) DockerInfo() (*DockerInfo, error) {
 //EventChannel connects to the Docker socket and executes the docker events
 //command, this returns a channel for receiving those events, and an error
 func (client *Client) EventChannel() (chan DockerEventMessage, chan interface{}, error) {
-	response, err := client.Request(ApiPrefix+"/events", "GET", nil)
+	response, err := client.Request(APIPrefix+"/events", "GET", nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -164,7 +166,7 @@ func (client *Client) EventChannel() (chan DockerEventMessage, chan interface{},
 //via it's /inspect URI
 func (client *Client) InspectContainer(containerID string) (*DockerContainerInfo, error) {
 	var info DockerContainerInfo
-	urlPath := ApiPrefix + "/containers/" + containerID + "/json"
+	urlPath := APIPrefix + "/containers/" + containerID + "/json"
 	response, err := client.Request(urlPath, "GET", nil)
 
 	if err != nil {
@@ -188,7 +190,7 @@ func (client *Client) InspectContainer(containerID string) (*DockerContainerInfo
 //ListContainers lists all of the running containers.
 func (client *Client) ListContainers() ([]DockerContainerListInfo, error) {
 	var info []DockerContainerListInfo
-	response, err := client.Request(ApiPrefix+"/containers/json", "GET", nil)
+	response, err := client.Request(APIPrefix+"/containers/json", "GET", nil)
 
 	if err != nil {
 		return nil, err
@@ -213,7 +215,7 @@ func (client *Client) ListContainers() ([]DockerContainerListInfo, error) {
 func (client *Client) InspectImage(imageID string) (*DockerImageInfo, error) {
 	var info DockerImageInfo
 
-	urlPath := ApiPrefix + "/images/" + imageID + "/json"
+	urlPath := APIPrefix + "/images/" + imageID + "/json"
 	response, err := client.Request(urlPath, "GET", nil)
 
 	if err != nil {
@@ -238,7 +240,7 @@ func (client *Client) InspectImage(imageID string) (*DockerImageInfo, error) {
 func (client *Client) InspectNetwork(networkID string) (*DockerNetworkInfo, error) {
 	var info DockerNetworkInfo
 
-	urlPath := ApiPrefix + "/networks/" + networkID
+	urlPath := APIPrefix + "/networks/" + networkID
 	response, err := client.Request(urlPath, "GET", nil)
 	if err != nil {
 		return nil, err
@@ -295,7 +297,7 @@ func (client *Client) ContainerTop(containerID string) ([]*ProcessEntry, error) 
 	var processes []*ProcessEntry
 	var processList DockerContainerProcessList
 
-	urlPath := ApiPrefix + "/containers/" + containerID + "/top"
+	urlPath := APIPrefix + "/containers/" + containerID + "/top"
 	response, err := client.Request(urlPath, "GET", nil)
 	if err != nil {
 		return nil, err
@@ -330,7 +332,7 @@ func (client *Client) ContainerTop(containerID string) ([]*ProcessEntry, error) 
 func (client *Client) ContainerDiff(containerID string) (fileList []DockerFileChange,
 	err error) {
 
-	urlPath := ApiPrefix + "/containers/" + containerID + "/changes"
+	urlPath := APIPrefix + "/containers/" + containerID + "/changes"
 	response, err := client.Request(urlPath, "GET", nil)
 	if err != nil {
 		return nil, err
@@ -351,7 +353,7 @@ func (client *Client) ContainerDiff(containerID string) (fileList []DockerFileCh
 
 //RestartContainer restarts the container with the given containerID.
 func (client *Client) RestartContainer(containerID string) (err error) {
-	urlPath := ApiPrefix + "/containers/" + containerID + "/restart"
+	urlPath := APIPrefix + "/containers/" + containerID + "/restart"
 	response, err := client.Request(urlPath, "POST", nil)
 	if err != nil {
 		return err
@@ -367,7 +369,7 @@ func (client *Client) KillContainer(containerID, signal string) (err error) {
 	query := url.Values{}
 	query.Set("signal", signal)
 
-	url := ApiPrefix + "/containers/" + containerID + "/kill"
+	url := APIPrefix + "/containers/" + containerID + "/kill"
 	resp, err := client.Request(url, "POST", &query)
 
 	if err != nil {

--- a/pkg/container/c8dockerclient/client_test.go
+++ b/pkg/container/c8dockerclient/client_test.go
@@ -489,7 +489,7 @@ func TestContainerInspectWithMount(t *testing.T) {
 		t.Fatalf("Unexpected number of mounts %d", len(containerInfo.Mounts))
 	}
 	mount := containerInfo.Mounts[0]
-	if mount.Type != MOUNT_TYPE_BIND {
+	if mount.Type != mountTypeBind {
 		t.Fatalf("Unexpected mount type %s", mount.Type)
 	}
 
@@ -535,11 +535,11 @@ func TestContainerDiffV1_12_2(t *testing.T) {
 		Kind uint8
 		Path string
 	}{
-		{DIFF_MODIFIED, "/bin"},      // 0 stands for change in directory / file
-		{DIFF_DELETED, "/bin/touch"}, // 2 stands for removed / deleted file or directory
-		{DIFF_ADDED, "/foo"},         // 1 stands for directory / file added
-		{DIFF_MODIFIED, "/root"},
-		{DIFF_ADDED, "/root/.ash_history"},
+		{diffModified, "/bin"},      // 0 stands for change in directory / file
+		{diffDeleted, "/bin/touch"}, // 2 stands for removed / deleted file or directory
+		{diffAdded, "/foo"},         // 1 stands for directory / file added
+		{diffModified, "/root"},
+		{diffAdded, "/root/.ash_history"},
 	}
 	for i := 0; i < 5; i++ {
 		if containerDiff[i].Kind != expectedValues[i].Kind {

--- a/pkg/container/c8dockerclient/dockertypes.go
+++ b/pkg/container/c8dockerclient/dockertypes.go
@@ -26,11 +26,9 @@ import (
 	"time"
 )
 
-const (
-	MOUNT_TYPE_BIND = "bind"
-)
+const mountTypeBind = "bind"
 
-//DockerInfo represents the information extracted from a docker info command.
+// DockerInfo represents the information extracted from a docker info command.
 type DockerInfo struct {
 	DockerID          string `json:"ID"`
 	DockerVersion     string `json:"ServerVersion"`
@@ -53,7 +51,7 @@ func (info *DockerInfo) String() string {
 	return output
 }
 
-//DockerEventActor represents the container or image that a Docker Event affects
+// DockerEventActor represents the container or image that a Docker Event affects
 type DockerEventActor struct {
 	ID         string            `json:"ID"`
 	Attributes map[string]string `json:"Attributes"`
@@ -68,7 +66,7 @@ func (actor *DockerEventActor) String() string {
 	return output
 }
 
-//DockerEventMessage encapsulates all information about a Docker event.
+// DockerEventMessage encapsulates all information about a Docker event.
 type DockerEventMessage struct {
 	Status   string `json:"status,omitempty"`
 	ID       string `json:"id,omitempty"`
@@ -93,8 +91,8 @@ func (event *DockerEventMessage) String() string {
 	return output
 }
 
-//DockerPortForward contains the container's host's forwarded IP and ports
-//e.g. port 2222 on an external IP of a host is actually passed to that container
+// DockerPortForward contains the container's host's forwarded IP and ports
+// e.g. port 2222 on an external IP of a host is actually passed to that container
 type DockerPortForward struct {
 	HostIP   string `json:"HostIp"`
 	HostPort string `json:"HostPort"`
@@ -134,8 +132,8 @@ func (settings *DockerContainerNetworkSettings) String() string {
 	return output
 }
 
-//DockerContainerState represents when the container was started and its ProcessID.
-//This is a sub-structure of DockerContainerInfo
+// DockerContainerState represents when the container was started and its ProcessID.
+// This is a sub-structure of DockerContainerInfo
 type DockerContainerState struct {
 	StartTime time.Time `json:"StartedAt"`
 	//PIDs in linux are limited to 4,000,000
@@ -143,7 +141,7 @@ type DockerContainerState struct {
 	ProcessID uint64 `json:"Pid"`
 }
 
-//DockerVolumeMounts represents the metadata associated.
+// DockerVolumeMounts represents the metadata associated.
 type DockerVolumeMounts struct {
 	Type        string `json:"Type"`        // this is the type of volume (bind)
 	Source      string `json:"Source"`      // this is the file path in the container host
@@ -154,7 +152,7 @@ type DockerVolumeMounts struct {
 	// propagated see https://lwn.net/Articles/689856/
 }
 
-//DockerContainerInfo represents the result of inspecting a docker container.
+// DockerContainerInfo represents the result of inspecting a docker container.
 type DockerContainerInfo struct {
 	Name            string                         `json:"Name"`
 	Path            string                         `json:"Path"`
@@ -183,9 +181,9 @@ func (info *DockerContainerInfo) String() string {
 	return output
 }
 
-//DockerContainerListInfo lists the ContainerID.
-//The information returned by ContainerList (/containers/json)
-//This type is used in container-enumeration at daemon start-up
+// DockerContainerListInfo lists the ContainerID.
+// The information returned by ContainerList (/containers/json)
+// This type is used in container-enumeration at daemon start-up
 type DockerContainerListInfo struct {
 	//The only field we need is ContainerID, we then Inspect it to
 	//get DockerContainerInfo
@@ -196,17 +194,17 @@ func (container *DockerContainerListInfo) String() string {
 	return "ContainerId: " + container.ContainerID + "\n"
 }
 
-//RootFSLayers represents the RootFS json object found when inspecting an image.
-//This represents all of the Image SHA1s that comprise the layers of this image.
+// RootFSLayers represents the RootFS json object found when inspecting an image.
+// This represents all of the Image SHA1s that comprise the layers of this image.
 type RootFSLayers struct {
 	Type   string   `json:"Type"`
 	Layers []string `json:"Layers"`
 }
 
-//DockerImageInfo represents the JSON object returned by ImageInspect
+// DockerImageInfo represents the JSON object returned by ImageInspect
 // (/images/<imageID>/json). The only field currently of interest at
 // time of writing is RepoTags
-//TODO: add layer information here
+// TODO: add layer information here
 type DockerImageInfo struct {
 	ImageID  string       `json:"ID"`
 	ParentID string       `json:"Parent"`
@@ -238,7 +236,7 @@ func (network *DockerNetworkInfo) String() string {
 	return output
 }
 
-//ProcessEntry represents a node in a process tree as found from docker top
+// ProcessEntry represents a node in a process tree as found from docker top
 type ProcessEntry struct {
 	User            string `json:"user"`
 	Command         string `json:"command"`
@@ -256,8 +254,8 @@ func (process *ProcessEntry) String() string {
 	return output
 }
 
-//DockerContainerProcessList is a helper struct for parsing the json
-//from Docker's Top command
+// DockerContainerProcessList is a helper struct for parsing the json
+// from Docker's Top command
 type DockerContainerProcessList struct {
 	Processes [][]string `json:"Processes"`
 	Titles    []string   `json:"Titles"`
@@ -281,12 +279,12 @@ func (processList *DockerContainerProcessList) String() string {
 }
 
 const (
-	DIFF_MODIFIED uint8 = 0
-	DIFF_ADDED    uint8 = 1
-	DIFF_DELETED  uint8 = 2
+	diffModified uint8 = 0
+	diffAdded    uint8 = 1
+	diffDeleted  uint8 = 2
 )
 
-//DockerFileChange is the json object returned by docker diff
+// DockerFileChange is the json object returned by docker diff
 type DockerFileChange struct {
 	Kind uint8  `json:"kind"`
 	Path string `json:"path"`

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -77,6 +77,8 @@ func getDockerContainerDir() string {
 // Docker container configuration file format V2
 // ----------------------------------------------------------------------------
 
+// DockerConfigState is a structure representing the configuration state of a
+// Docker container.
 type DockerConfigState struct {
 	Running           bool      `json:"Running"`
 	Paused            bool      `json:"Paused"`
@@ -91,6 +93,7 @@ type DockerConfigState struct {
 	ExitCode          int       `json:"ExitCode"`
 }
 
+// DockerConfigConfig is a structure representing a Docker image.
 type DockerConfigConfig struct {
 	Hostname   string `json:"Hostname"`
 	Domainname string `json:"Domainname"`
@@ -101,6 +104,7 @@ type DockerConfigConfig struct {
 	// XXX: ...
 }
 
+// DockerConfigV2 is a structure representing a Docker container.
 type DockerConfigV2 struct {
 	// XXX: Fill in as needed...
 	ID     string             `json:"ID"`

--- a/pkg/container/oci.go
+++ b/pkg/container/oci.go
@@ -61,7 +61,7 @@ func getOciContainerDir() string {
 	return config.Sensor.OciContainerDir
 }
 
-type ociConfigJson struct {
+type ociConfigJSON struct {
 	OciVersion string `json:"ociVersion"`
 	Root       struct {
 		Path string `json:"path"`
@@ -86,15 +86,15 @@ func onOciConfigUpdate(configPath string) (*ociEvent, error) {
 		return nil, err
 	}
 
-	configJson := ociConfigJson{}
-	json.Unmarshal(data, &configJson)
+	configJSON := ociConfigJSON{}
+	json.Unmarshal(data, &configJSON)
 
 	containerID := filepath.Base(filepath.Dir(configPath))
 
 	ev := &ociEvent{
 		ID:          containerID,
 		State:       ociRunning,
-		CgroupsPath: configJson.Linux.CgroupsPath,
+		CgroupsPath: configJSON.Linux.CgroupsPath,
 		ConfigJSON:  string(data),
 	}
 

--- a/pkg/sensor/container.go
+++ b/pkg/sensor/container.go
@@ -38,7 +38,7 @@ var containerEventTypes = expression.FieldTypeMap{
 	"exit_core_dumped": api.ValueType_BOOL,
 }
 
-type ContainerEventRepeater struct {
+type containerEventRepeater struct {
 	repeater *stream.Repeater
 	sensor   *Sensor
 
@@ -74,7 +74,7 @@ func newContainerDestroyed(cID string) *api.ContainerEvent {
 	}
 }
 
-func (cer *ContainerEventRepeater) translateContainerEvents(e interface{}) interface{} {
+func (cer *containerEventRepeater) translateContainerEvents(e interface{}) interface{} {
 	ce := e.(*container.Event)
 	var ece *api.ContainerEvent
 
@@ -190,13 +190,13 @@ func (cer *ContainerEventRepeater) translateContainerEvents(e interface{}) inter
 	return nil
 }
 
-func NewContainerEventRepeater(sensor *Sensor) (*ContainerEventRepeater, error) {
+func newContainerEventRepeater(sensor *Sensor) (*containerEventRepeater, error) {
 	ces, err := container.NewEventStream()
 	if err != nil {
 		return nil, err
 	}
 
-	cer := &ContainerEventRepeater{
+	cer := &containerEventRepeater{
 		sensor: sensor,
 	}
 
@@ -230,7 +230,7 @@ type containerEventFilter struct {
 	expr *expression.Expression
 }
 
-func (cer *ContainerEventRepeater) NewEventStream(sub *api.Subscription) (*stream.Stream, error) {
+func (cer *containerEventRepeater) newEventStream(sub *api.Subscription) (*stream.Stream, error) {
 	filters := make(map[api.ContainerEventType]*containerEventFilter)
 	exprs := make(map[api.ContainerEventType]*api.Expression)
 	for _, cef := range sub.EventFilter.ContainerEvents {
@@ -319,7 +319,7 @@ func newContainerFilter(ecf *api.ContainerFilter) *containerFilter {
 	cf := &containerFilter{}
 
 	for _, v := range ecf.Ids {
-		cf.addContainerId(v)
+		cf.addContainerID(v)
 	}
 
 	for _, v := range ecf.Names {
@@ -327,7 +327,7 @@ func newContainerFilter(ecf *api.ContainerFilter) *containerFilter {
 	}
 
 	for _, v := range ecf.ImageIds {
-		cf.addImageId(v)
+		cf.addImageID(v)
 	}
 
 	for _, v := range ecf.ImageNames {
@@ -344,7 +344,7 @@ type containerFilter struct {
 	imageGlobs     map[string]glob.Glob
 }
 
-func (c *containerFilter) addContainerId(cid string) {
+func (c *containerFilter) addContainerID(cid string) {
 	if len(cid) > 0 {
 		if c.containerIds == nil {
 			c.containerIds = make(map[string]bool)
@@ -353,7 +353,7 @@ func (c *containerFilter) addContainerId(cid string) {
 	}
 }
 
-func (c *containerFilter) removeContainerId(cid string) {
+func (c *containerFilter) removeContainerID(cid string) {
 	delete(c.containerIds, cid)
 }
 
@@ -366,7 +366,7 @@ func (c *containerFilter) addContainerName(cname string) {
 	}
 }
 
-func (c *containerFilter) addImageId(iid string) {
+func (c *containerFilter) addImageID(iid string) {
 	if len(iid) > 0 {
 		if c.imageIds == nil {
 			c.imageIds = make(map[string]bool)
@@ -414,19 +414,19 @@ func (c *containerFilter) FilterFunc(i interface{}) bool {
 		//
 
 		if c.containerNames[cev.Name] {
-			c.addContainerId(e.ContainerId)
+			c.addContainerID(e.ContainerId)
 			return true
 		}
 
 		if c.imageIds[cev.ImageId] {
-			c.addContainerId(e.ContainerId)
+			c.addContainerID(e.ContainerId)
 			return true
 		}
 
 		if c.imageGlobs != nil && cev.ImageName != "" {
 			for _, g := range c.imageGlobs {
 				if g.Match(cev.ImageName) {
-					c.addContainerId(e.ContainerId)
+					c.addContainerID(e.ContainerId)
 					return true
 				}
 			}
@@ -443,7 +443,7 @@ func (c *containerFilter) DoFunc(i interface{}) {
 	case *api.Event_Container:
 		cev := e.GetContainer()
 		if cev.Type == api.ContainerEventType_CONTAINER_EVENT_TYPE_DESTROYED {
-			c.removeContainerId(e.ContainerId)
+			c.removeContainerID(e.ContainerId)
 		}
 	}
 }

--- a/pkg/sensor/kprobe.go
+++ b/pkg/sensor/kprobe.go
@@ -35,7 +35,7 @@ type kprobeFilter struct {
 	sensor    *Sensor
 }
 
-var validSymbolRegex *regexp.Regexp = regexp.MustCompile("^[A-Za-z_]{1}[\\w]*$")
+var validSymbolRegex = regexp.MustCompile("^[A-Za-z_]{1}[\\w]*$")
 
 func newKprobeFilter(kef *api.KernelFunctionCallFilter) *kprobeFilter {
 	// The symbol must begin with [A-Za-z_] and contain only [A-Za-z0-9_]

--- a/pkg/sensor/metrics.go
+++ b/pkg/sensor/metrics.go
@@ -14,7 +14,7 @@
 
 package sensor
 
-// Counters used for metrics
+// MetricsCounters is used for tracking metrics information in the sensor
 type MetricsCounters struct {
 	// Number of events created during the sample period
 	Events uint64

--- a/pkg/sensor/network.go
+++ b/pkg/sensor/network.go
@@ -48,8 +48,8 @@ func (f *networkFilter) newNetworkEvent(eventType api.NetworkEventType, sample *
 	// If this even contains a network address, throw away any family that
 	// we do not support without doing the extra work of creating an event
 	// just to throw it away
-	family, have_family := data["sa_family"].(uint16)
-	if have_family {
+	family, haveFamily := data["sa_family"].(uint16)
+	if haveFamily {
 		switch family {
 		case 1: // AF_LOCAL
 			break
@@ -70,7 +70,7 @@ func (f *networkFilter) newNetworkEvent(eventType api.NetworkEventType, sample *
 	}
 	network := event.Event.(*api.Event_Network).Network
 
-	if have_family {
+	if haveFamily {
 		switch family {
 		case 1: // AF_LOCAL
 			network.Address = &api.NetworkAddress{

--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -49,9 +49,9 @@ func (f *processFilter) decodeSchedProcessFork(sample *perf.SampleRecord, data p
 		},
 	}
 
-	childId, ok := f.sensor.processCache.ProcessId(int(childPid))
+	childID, ok := f.sensor.processCache.ProcessID(int(childPid))
 	if ok {
-		ev.GetProcess().ForkChildId = childId
+		ev.GetProcess().ForkChildId = childID
 	}
 
 	return ev, nil

--- a/pkg/sensor/process_info_test.go
+++ b/pkg/sensor/process_info_test.go
@@ -36,7 +36,7 @@ BenchmarkContainerCacheMissParallel-8   	  300000	      5789 ns/op
 
 const arrayTaskCacheSize = 32768
 
-var values []task = []task{
+var values = []task{
 	{1, 2, 3, 0x120011, "foo", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
 	{1, 2, 3, 0x120011, "bar", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
 	{1, 2, 3, 0x120011, "baz", nil, cred{}, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2"},
@@ -56,21 +56,21 @@ func TestCaches(t *testing.T) {
 	for i := arrayTaskCacheSize - 1; i >= 0; i-- {
 		var tk task
 		if arrayCache.LookupTask(i, &tk) {
-			cid := tk.containerId
+			cid := tk.containerID
 
-			if cid != values[i%4].containerId {
+			if cid != values[i%4].containerID {
 				t.Fatalf("Expected %s for pid %d, got %s",
-					values[i%4].containerId, i, cid)
+					values[i%4].containerID, i, cid)
 			}
 
 		}
 
 		if mapCache.LookupTask(i, &tk) {
-			cid := tk.containerId
+			cid := tk.containerID
 
-			if cid != values[i%4].containerId {
+			if cid != values[i%4].containerID {
 				t.Fatalf("Expected %s for pid %d, got %s",
-					values[i%4].containerId, i, cid)
+					values[i%4].containerID, i, cid)
 			}
 
 		}

--- a/pkg/sensor/telemetry.go
+++ b/pkg/sensor/telemetry.go
@@ -27,6 +27,9 @@ import (
 	"google.golang.org/grpc"
 )
 
+// TelemetryService is a service that can be used with the ServiceManager to
+// process telemetry subscription requests and stream the resulting telemetry
+// events.
 type TelemetryService struct {
 	server *grpc.Server
 	sensor *Sensor
@@ -34,6 +37,8 @@ type TelemetryService struct {
 	address string
 }
 
+// NewTelemetryService creates a new TelemetryService instance that can be used
+// with a ServiceManager instance.
 func NewTelemetryService(sensor *Sensor, address string) *TelemetryService {
 	return &TelemetryService{
 		address: address,
@@ -41,10 +46,14 @@ func NewTelemetryService(sensor *Sensor, address string) *TelemetryService {
 	}
 }
 
+// Name returns the human-readable name of the TelemetryService.
 func (ts *TelemetryService) Name() string {
 	return "gRPC Telemetry Server"
 }
 
+// Serve is the main entrypoint for the TelemetryService. It is normally called
+// by the ServiceManager. It will service requests indefinitely from the calling
+// Goroutine.
 func (ts *TelemetryService) Serve() error {
 	var (
 		err error
@@ -103,6 +112,7 @@ func (ts *TelemetryService) Serve() error {
 	return ts.server.Serve(lis)
 }
 
+// Stop will stop a running TelemetryService.
 func (ts *TelemetryService) Stop() {
 	ts.server.GracefulStop()
 }

--- a/pkg/services/manager.go
+++ b/pkg/services/manager.go
@@ -30,6 +30,7 @@ type Service interface {
 	Stop()
 }
 
+// ServiceManager controls an arbitrary number of running services.
 type ServiceManager struct {
 	sync.Mutex
 
@@ -40,16 +41,20 @@ type ServiceManager struct {
 	stopChan chan struct{}
 }
 
+// NewServiceManager creates a new ServiceManager instance.
 func NewServiceManager() *ServiceManager {
 	return &ServiceManager{}
 }
 
+// RegisterService registers a Service for management with a ServiceManager.
 func (sm *ServiceManager) RegisterService(service Service) {
 	sm.Lock()
 	sm.services = append(sm.services, service)
 	sm.Unlock()
 }
 
+// Run starts and runs all services registered with a ServiceManager. This
+// function does not return until the ServiceManager is stopped via Stop.
 func (sm *ServiceManager) Run() {
 	sigChan := make(chan os.Signal)
 	signal.Notify(sigChan, os.Interrupt)
@@ -96,6 +101,8 @@ func (sm *ServiceManager) Run() {
 	wg.Wait()
 }
 
+// Stop stops a running ServiceManager. If the ServiceManager is not running,
+// this function does nothing.
 func (sm *ServiceManager) Stop() {
 	sm.Lock()
 	defer sm.Unlock()

--- a/pkg/services/profiling.go
+++ b/pkg/services/profiling.go
@@ -25,22 +25,29 @@ import (
 	"github.com/golang/glog"
 )
 
+// ProfilingService is a service that returns profiling information via a
+// HTTP server.
 type ProfilingService struct {
 	server *http.Server
 
 	address string
 }
 
+// NewProfilingService creates a new ProfilingService instance bound to
+// a specified address.
 func NewProfilingService(address string) *ProfilingService {
 	return &ProfilingService{
 		address: address,
 	}
 }
 
+// Name returns a human-readable name for a ProfilingService.
 func (ps *ProfilingService) Name() string {
 	return "Profiling HTTP endpoint"
 }
 
+// Serve runs a ProfilingService. It sets up the HTTP endpoint and services
+// requests until the service is stopped. It runs on the calling Goroutine.
 func (ps *ProfilingService) Serve() error {
 	glog.V(1).Infof("Serving profiling HTTP endpoints on %s",
 		ps.address)
@@ -57,6 +64,7 @@ func (ps *ProfilingService) Serve() error {
 	return err
 }
 
+// Stop stops a running ProfilingService.
 func (ps *ProfilingService) Stop() {
 	ps.server.Shutdown(context.Background())
 }

--- a/pkg/stream/joiner.go
+++ b/pkg/stream/joiner.go
@@ -21,6 +21,8 @@ import (
 	"github.com/golang/glog"
 )
 
+// Joiner is a construct that combines multiple input streams into a single
+// output stream.
 type Joiner struct {
 	ctrl chan<- interface{}
 }
@@ -181,6 +183,7 @@ func NewJoiner() (*Stream, *Joiner) {
 	}
 }
 
+// Add adds a new input stream to an existing Joiner.
 func (J *Joiner) Add(s *Stream) bool {
 	reply := make(chan bool)
 
@@ -194,6 +197,7 @@ func (J *Joiner) Add(s *Stream) bool {
 	return ok
 }
 
+// Remove removes an input stream from an existing Joiner.
 func (J *Joiner) Remove(s *Stream) bool {
 	reply := make(chan bool)
 
@@ -207,14 +211,17 @@ func (J *Joiner) Remove(s *Stream) bool {
 	return ok
 }
 
+// On enables the output from a Joiner.
 func (J *Joiner) On() {
 	J.ctrl <- true
 }
 
+// Off disables the output from a Joiner.
 func (J *Joiner) Off() {
 	J.ctrl <- false
 }
 
+// Close closes a Joiner.
 func (J *Joiner) Close() {
 	// Closing the control channel signals the loop to shutdown.
 	close(J.ctrl)

--- a/pkg/stream/repeater.go
+++ b/pkg/stream/repeater.go
@@ -16,6 +16,8 @@ package stream
 
 import "reflect"
 
+// Repeater is a stream that repeats elements from one input to multiple output
+// streams.
 type Repeater struct {
 	ctrl chan<- interface{}
 }
@@ -213,6 +215,7 @@ func NewRepeater(in *Stream) *Repeater {
 	}
 }
 
+// NewStream creates a new output stream from a Repeater stream.
 func (r *Repeater) NewStream() *Stream {
 	reply := make(chan *Stream)
 
@@ -225,6 +228,7 @@ func (r *Repeater) NewStream() *Stream {
 	return rep
 }
 
+// Close closes the input stream of a Repeater.
 func (r *Repeater) Close() {
 	// Closing the control channel signals to the looper to shutdown.
 	close(r.ctrl)

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -227,6 +227,7 @@ func Ticker(d time.Duration) *Stream {
 // data channel closes, the operator closes its downstream data channel also.
 //
 
+// DoFunc is the signature of a function that is called by Do
 type DoFunc func(interface{})
 
 // Do adds an operator in the stream that calls the given function for
@@ -256,6 +257,7 @@ func Do(in *Stream, f DoFunc) *Stream {
 	}
 }
 
+// MapFunc is the signature of a function that is called by Map
 type MapFunc func(interface{}) interface{}
 
 // Map adds an operator in the stream that calls the given function for
@@ -284,8 +286,11 @@ func Map(in *Stream, f MapFunc) *Stream {
 	}
 }
 
+// FilterFunc is the signature of a function that is called by Filter
 type FilterFunc func(interface{}) bool
 
+// Filter adds a filter to a stream. For each element in the stream, a false
+// return from the filter function causes the element to be discarded.
 func Filter(in *Stream, f FilterFunc) *Stream {
 	data := make(chan interface{}, config.Sensor.ChannelBufferLength)
 
@@ -601,7 +606,7 @@ func OnOffValve(in *Stream) (*Stream, chan<- bool) {
 	return s, ctrl
 }
 
-// Throttles the number of events emitted by the stream
+// Throttle limits the number of events emitted by the stream
 func Throttle(in *Stream, mod api.ThrottleModifier) *Stream {
 	data := make(chan interface{})
 
@@ -640,7 +645,7 @@ func Throttle(in *Stream, mod api.ThrottleModifier) *Stream {
 	}
 }
 
-// Limits the number of results returned
+// Limit limits the number of results returned
 func Limit(in *Stream, mod api.LimitModifier) *Stream {
 	data := make(chan interface{})
 
@@ -648,7 +653,7 @@ func Limit(in *Stream, mod api.LimitModifier) *Stream {
 		defer close(data)
 
 		// Keep a count of how many results have been returned
-		var count int64 = 0
+		var count int64
 		for {
 			// Only send a result up to the specified `Limit`
 			if count < mod.Limit {
@@ -678,6 +683,7 @@ func Limit(in *Stream, mod api.LimitModifier) *Stream {
 // typically used to aggregate a value over the entire stream.
 // ----------------------------------------------------------------------------
 
+// ReduceFunc is the signature of a function called by Reduce.
 type ReduceFunc func(interface{}, interface{}) interface{}
 
 // Reduce adds a terminator onto the stream that accumulates a value using

--- a/pkg/sys/mount.go
+++ b/pkg/sys/mount.go
@@ -248,6 +248,9 @@ func PerfEventDir() string {
 	return ""
 }
 
+// MountTempFS mounts a filesystem. It is primarily a wrapper around unix.Mount,
+// but it also ensures that the mountpoint exists before attempting to mount to
+// it.
 func MountTempFS(source string, target string, fstype string, flags uintptr, data string) error {
 	// Make sure that `target` exists.
 	err := os.MkdirAll(target, 0500)
@@ -265,6 +268,9 @@ func MountTempFS(source string, target string, fstype string, flags uintptr, dat
 	return nil
 }
 
+// UnmountTempFS unmounts a filesystem. It is primarily a wrapper around
+// unix.Unmount, but it also removes the mountpoint after the filesystem
+// is unmounted.
 func UnmountTempFS(dir string, fstype string) error {
 	err := unix.Unmount(dir, 0)
 	if err != nil {

--- a/pkg/sys/perf/consts.go
+++ b/pkg/sys/perf/consts.go
@@ -1,0 +1,205 @@
+// Code generated automatically. DO NOT EDIT.
+// It isn't really, but the above line causes golint to not check this file.
+// This file contains Linux kernel constants that do not conform to Go's
+// usual naming conventions. It may at some point in the future become
+// automatically generated.
+
+// Copyright 2017 Capsule8, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perf
+
+//
+// We support PERF_ATTR_SIZE_VER0, which is the first published version
+//
+const sizeofPerfEventAttrVer0 = 64
+const sizeofPerfEventAttrVer1 = 72  // Linux 2.6.33
+const sizeofPerfEventAttrVer2 = 80  // Linux 3.4
+const sizeofPerfEventAttrVer3 = 96  // Linux 3.7
+const sizeofPerfEventAttrVer4 = 104 // Linux 3.19
+const sizeofPerfEventAttrVer5 = 112 // Linux 4.1
+
+const sizeofPerfEventAttr = sizeofPerfEventAttrVer0
+
+const (
+	PERF_EVENT_IOC_ENABLE       uintptr = 0x2400 + 0
+	PERF_EVENT_IOC_DISABLE              = 0x2400 + 1
+	PERF_EVENT_IOC_REFRESH              = 0x2400 + 2
+	PERF_EVENT_IOC_RESET                = 0x2400 + 3
+	PERF_EVENT_IOC_PERIOD               = 0x40080000 | (0x2400 + 4)
+	PERF_EVENT_IOC_SET_OUTPUT           = 0x2400 + 5
+	PERF_EVENT_IOC_SET_FILTER           = 0x40080000 | (0x2400 + 6)
+	PERF_EVENT_IOC_ID                   = 0x80080000 | (0x2400 + 7)
+	PERF_EVENT_IOC_SET_BPF              = 0x40040000 | (0x2400 + 8)
+	PERF_EVENT_IOC_PAUSE_OUTPUT         = 0x40040000 | (0x2400 + 9)
+)
+
+const (
+	PERF_EVENT_IOC_FLAG_GROUP uintptr = 1 << iota
+)
+
+const (
+	PERF_FLAG_FD_NO_GROUP uintptr = 1 << iota
+	PERF_FLAG_FD_OUTPUT
+	PERF_FLAG_PID_CGROUP
+	PERF_FLAG_FD_CLOEXEC
+)
+
+const (
+	PERF_FORMAT_TOTAL_TIME_ENABLED uint64 = 1 << iota
+	PERF_FORMAT_TOTAL_TIME_RUNNING
+	PERF_FORMAT_ID
+	PERF_FORMAT_GROUP
+)
+
+const (
+	PERF_RECORD_MISC_COMM_EXEC uint16 = (1 << 13)
+)
+
+const (
+	PERF_TYPE_HARDWARE uint32 = iota
+	PERF_TYPE_SOFTWARE
+	PERF_TYPE_TRACEPOINT
+	PERF_TYPE_HW_CACHE
+	PERF_TYPE_RAW
+	PERF_TYPE_BREAKPOINT
+	PERF_TYPE_MAX
+)
+
+const (
+	PERF_COUNT_HW_CPU_CYCLES uint64 = iota
+	PERF_COUNT_HW_INSTRUCTIONS
+	PERF_COUNT_HW_CACHE_REFERENCES
+	PERF_COUNT_HW_CACHE_MISSES
+	PERF_COUNT_HW_BRANCH_INSTRUCTIONS
+	PERF_COUNT_HW_BRANCH_MISSES
+	PERF_COUNT_HW_BUS_CYCLES
+	PERF_COUNT_HW_STALLED_CYCLES_FRONTEND
+	PERF_COUNT_HW_STALLED_CYCLES_BACKEND
+	PERF_COUNT_HW_REF_CPU_CYCLES
+	PERF_COUNT_HW_MAX
+)
+
+const (
+	PERF_COUNT_HW_CACHE_L1D uint64 = iota
+	PERF_COUNT_HW_CACHE_L1I
+	PERF_COUNT_HW_CACHE_LL
+	PERF_COUNT_HW_CACHE_DTLB
+	PERF_COUNT_HW_CACHE_ITLB
+	PERF_COUNT_HW_CACHE_BPU
+	PERF_COUNT_HW_CACHE_NODE
+	PERF_COUNT_HW_CACHE_MAX
+)
+
+const (
+	PERF_COUNT_HW_CACHE_OP_READ uint64 = iota
+	PERF_COUNT_HW_CACHE_OP_WRITE
+	PERF_COUNT_HW_CACHE_OP_PREFETCH
+	PERF_COUNT_HW_CACHE_OP_MAX
+)
+
+const (
+	PERF_COUNT_HW_CACHE_RESULT_ACCESS uint64 = iota
+	PERF_COUNT_HW_CACHE_RESULT_MISS
+	PERF_COUNT_HW_CACHE_RESULT_MAX
+)
+
+const (
+	PERF_COUNT_SW_CPU_CLOCK uint64 = iota
+	PERF_COUNT_SW_TASK_CLOCK
+	PERF_COUNT_SW_PAGE_FAULTS
+	PERF_COUNT_SW_CONTEXT_SWITCHES
+	PERF_COUNT_SW_CPU_MIGRATIONS
+	PERF_COUNT_SW_PAGE_FAULTS_MIN
+	PERF_COUNT_SW_PAGE_FAULTS_MAJ
+	PERF_COUNT_SW_ALIGNMENT_FAULTS
+	PERF_COUNT_SW_EMULATION_FAULTS
+	PERF_COUNT_SW_DUMMY
+	PERF_COUNT_BPF_OUTPUT
+	PERF_COUNT_SW_MAX
+)
+
+const (
+	PERF_RECORD_INVALID uint32 = iota
+	PERF_RECORD_MMAP
+	PERF_RECORD_LOST
+	PERF_RECORD_COMM
+	PERF_RECORD_EXIT
+	PERF_RECORD_THROTTLE
+	PERF_RECORD_UNTHROTTLE
+	PERF_RECORD_FORK
+	PERF_RECORD_READ
+	PERF_RECORD_SAMPLE
+	PERF_RECORD_MMAP2
+	PERF_RECORD_AUX
+	PERF_RECORD_ITRACE_START
+	PERF_RECORD_LOST_SAMPLES
+	PERF_RECORD_SWITCH
+	PERF_RECORD_SWITCH_CPU_WIDE
+	PERF_RECORD_MAX
+)
+
+const (
+	PERF_SAMPLE_IP uint64 = 1 << iota
+	PERF_SAMPLE_TID
+	PERF_SAMPLE_TIME
+	PERF_SAMPLE_ADDR
+	PERF_SAMPLE_READ
+	PERF_SAMPLE_CALLCHAIN
+	PERF_SAMPLE_ID
+	PERF_SAMPLE_CPU
+	PERF_SAMPLE_PERIOD
+	PERF_SAMPLE_STREAM_ID
+	PERF_SAMPLE_RAW
+	PERF_SAMPLE_BRANCH_STACK
+	PERF_SAMPLE_REGS_USER
+	PERF_SAMPLE_STACK_USER
+	PERF_SAMPLE_WEIGHT
+	PERF_SAMPLE_DATA_SRC
+	PERF_SAMPLE_IDENTIFIER
+	PERF_SAMPLE_TRANSACTION
+	PERF_SAMPLE_REGS_INTR
+	PERF_SAMPLE_MAX
+)
+
+// Bitmasks for bitfield in EventAttr
+const (
+	eaDisabled = 1 << iota
+	eaInherit
+	eaPinned
+	eaExclusive
+	eaExclusiveUser
+	eaExclusiveKernel
+	eaExclusiveHV
+	eaExclusiveIdle
+	eaMmap
+	eaComm
+	eaFreq
+	eaInheritStat
+	eaEnableOnExec
+	eaTask
+	eaWatermark
+	eaPreciseIP1
+	eaPreciseIP2
+	eaMmapData
+	eaSampleIDAll
+	eaExcludeHost
+	eaExcludeGuest
+	eaExcludeCallchainKernel
+	eaExcludeCallchainUser
+	eaMmap2
+	eaCommExec
+	eaUseClockID
+	eaContextSwitch
+)

--- a/pkg/sys/perf/tracepoint_test.go
+++ b/pkg/sys/perf/tracepoint_test.go
@@ -57,28 +57,12 @@ func extractFiles(filename string, fn extractFileFn) error {
 	return nil
 }
 
-func testReadTraceEventID(name string, reader io.Reader) error {
-	if filepath.Base(name) != "id" {
-		return nil
-	}
-
-	_, err := ReadTraceEventID(filepath.Dir(name), reader)
-	return err
-}
-
-func TestReadTraceEventID(t *testing.T) {
-	err := extractFiles("testdata/events.tar.gz", testReadTraceEventID)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func testReadTraceEventFormat(name string, reader io.Reader) error {
 	if filepath.Base(name) != "format" {
 		return nil
 	}
 
-	_, _, err := ReadTraceEventFormat(filepath.Dir(name), reader)
+	_, _, err := readTraceEventFormat(filepath.Dir(name), reader)
 	return err
 }
 

--- a/pkg/sys/perf/types.go
+++ b/pkg/sys/perf/types.go
@@ -27,190 +27,6 @@ import (
 	"github.com/golang/glog"
 )
 
-//
-// We support PERF_ATTR_SIZE_VER0, which is the first published version
-//
-const sizeofPerfEventAttrVer0 = 64
-const sizeofPerfEventAttrVer1 = 72  // Linux 2.6.33
-const sizeofPerfEventAttrVer2 = 80  // Linux 3.4
-const sizeofPerfEventAttrVer3 = 96  // Linux 3.7
-const sizeofPerfEventAttrVer4 = 104 // Linux 3.19
-const sizeofPerfEventAttrVer5 = 112 // Linux 4.1
-
-const sizeofPerfEventAttr = sizeofPerfEventAttrVer0
-
-const (
-	PERF_EVENT_IOC_ENABLE       uintptr = 0x2400 + 0
-	PERF_EVENT_IOC_DISABLE              = 0x2400 + 1
-	PERF_EVENT_IOC_REFRESH              = 0x2400 + 2
-	PERF_EVENT_IOC_RESET                = 0x2400 + 3
-	PERF_EVENT_IOC_PERIOD               = 0x40080000 | (0x2400 + 4)
-	PERF_EVENT_IOC_SET_OUTPUT           = 0x2400 + 5
-	PERF_EVENT_IOC_SET_FILTER           = 0x40080000 | (0x2400 + 6)
-	PERF_EVENT_IOC_ID                   = 0x80080000 | (0x2400 + 7)
-	PERF_EVENT_IOC_SET_BPF              = 0x40040000 | (0x2400 + 8)
-	PERF_EVENT_IOC_PAUSE_OUTPUT         = 0x40040000 | (0x2400 + 9)
-)
-
-const (
-	PERF_EVENT_IOC_FLAG_GROUP uintptr = 1 << iota
-)
-
-const (
-	PERF_FLAG_FD_NO_GROUP uintptr = 1 << iota
-	PERF_FLAG_FD_OUTPUT
-	PERF_FLAG_PID_CGROUP
-	PERF_FLAG_FD_CLOEXEC
-)
-
-const (
-	PERF_FORMAT_TOTAL_TIME_ENABLED uint64 = 1 << iota
-	PERF_FORMAT_TOTAL_TIME_RUNNING
-	PERF_FORMAT_ID
-	PERF_FORMAT_GROUP
-)
-
-const (
-	PERF_RECORD_MISC_COMM_EXEC uint16 = (1 << 13)
-)
-
-const (
-	PERF_TYPE_HARDWARE uint32 = iota
-	PERF_TYPE_SOFTWARE
-	PERF_TYPE_TRACEPOINT
-	PERF_TYPE_HW_CACHE
-	PERF_TYPE_RAW
-	PERF_TYPE_BREAKPOINT
-	PERF_TYPE_MAX
-)
-
-const (
-	PERF_COUNT_HW_CPU_CYCLES uint64 = iota
-	PERF_COUNT_HW_INSTRUCTIONS
-	PERF_COUNT_HW_CACHE_REFERENCES
-	PERF_COUNT_HW_CACHE_MISSES
-	PERF_COUNT_HW_BRANCH_INSTRUCTIONS
-	PERF_COUNT_HW_BRANCH_MISSES
-	PERF_COUNT_HW_BUS_CYCLES
-	PERF_COUNT_HW_STALLED_CYCLES_FRONTEND
-	PERF_COUNT_HW_STALLED_CYCLES_BACKEND
-	PERF_COUNT_HW_REF_CPU_CYCLES
-	PERF_COUNT_HW_MAX
-)
-
-const (
-	PERF_COUNT_HW_CACHE_L1D uint64 = iota
-	PERF_COUNT_HW_CACHE_L1I
-	PERF_COUNT_HW_CACHE_LL
-	PERF_COUNT_HW_CACHE_DTLB
-	PERF_COUNT_HW_CACHE_ITLB
-	PERF_COUNT_HW_CACHE_BPU
-	PERF_COUNT_HW_CACHE_NODE
-	PERF_COUNT_HW_CACHE_MAX
-)
-
-const (
-	PERF_COUNT_HW_CACHE_OP_READ uint64 = iota
-	PERF_COUNT_HW_CACHE_OP_WRITE
-	PERF_COUNT_HW_CACHE_OP_PREFETCH
-	PERF_COUNT_HW_CACHE_OP_MAX
-)
-
-const (
-	PERF_COUNT_HW_CACHE_RESULT_ACCESS uint64 = iota
-	PERF_COUNT_HW_CACHE_RESULT_MISS
-	PERF_COUNT_HW_CACHE_RESULT_MAX
-)
-
-const (
-	PERF_COUNT_SW_CPU_CLOCK uint64 = iota
-	PERF_COUNT_SW_TASK_CLOCK
-	PERF_COUNT_SW_PAGE_FAULTS
-	PERF_COUNT_SW_CONTEXT_SWITCHES
-	PERF_COUNT_SW_CPU_MIGRATIONS
-	PERF_COUNT_SW_PAGE_FAULTS_MIN
-	PERF_COUNT_SW_PAGE_FAULTS_MAJ
-	PERF_COUNT_SW_ALIGNMENT_FAULTS
-	PERF_COUNT_SW_EMULATION_FAULTS
-	PERF_COUNT_SW_DUMMY
-	PERF_COUNT_BPF_OUTPUT
-	PERF_COUNT_SW_MAX
-)
-
-const (
-	PERF_RECORD_INVALID uint32 = iota
-	PERF_RECORD_MMAP
-	PERF_RECORD_LOST
-	PERF_RECORD_COMM
-	PERF_RECORD_EXIT
-	PERF_RECORD_THROTTLE
-	PERF_RECORD_UNTHROTTLE
-	PERF_RECORD_FORK
-	PERF_RECORD_READ
-	PERF_RECORD_SAMPLE
-	PERF_RECORD_MMAP2
-	PERF_RECORD_AUX
-	PERF_RECORD_ITRACE_START
-	PERF_RECORD_LOST_SAMPLES
-	PERF_RECORD_SWITCH
-	PERF_RECORD_SWITCH_CPU_WIDE
-	PERF_RECORD_MAX
-)
-
-const (
-	PERF_SAMPLE_IP uint64 = 1 << iota
-	PERF_SAMPLE_TID
-	PERF_SAMPLE_TIME
-	PERF_SAMPLE_ADDR
-	PERF_SAMPLE_READ
-	PERF_SAMPLE_CALLCHAIN
-	PERF_SAMPLE_ID
-	PERF_SAMPLE_CPU
-	PERF_SAMPLE_PERIOD
-	PERF_SAMPLE_STREAM_ID
-	PERF_SAMPLE_RAW
-	PERF_SAMPLE_BRANCH_STACK
-	PERF_SAMPLE_REGS_USER
-	PERF_SAMPLE_STACK_USER
-	PERF_SAMPLE_WEIGHT
-	PERF_SAMPLE_DATA_SRC
-	PERF_SAMPLE_IDENTIFIER
-	PERF_SAMPLE_TRANSACTION
-	PERF_SAMPLE_REGS_INTR
-	PERF_SAMPLE_MAX
-)
-
-// Bitmasks for bitfield in EventAttr
-const (
-	eaDisabled = 1 << iota
-	eaInherit
-	eaPinned
-	eaExclusive
-	eaExclusiveUser
-	eaExclusiveKernel
-	eaExclusiveHV
-	eaExclusiveIdle
-	eaMmap
-	eaComm
-	eaFreq
-	eaInheritStat
-	eaEnableOnExec
-	eaTask
-	eaWatermark
-	eaPreciseIP1
-	eaPreciseIP2
-	eaMmapData
-	eaSampleIDAll
-	eaExcludeHost
-	eaExcludeGuest
-	eaExcludeCallchainKernel
-	eaExcludeCallchainUser
-	eaMmap2
-	eaCommExec
-	eaUseClockID
-	eaContextSwitch
-)
-
 /*
    struct perf_event_attr {
        __u32 type;         // Type of event
@@ -566,6 +382,8 @@ func (eh *eventHeader) read(reader *bytes.Reader) error {
 	return nil
 }
 
+// CommRecord is a translation of the structure used by the Linux kernel for
+// PERF_RECORD_COMM samples into Go.
 type CommRecord struct {
 	Pid  uint32
 	Tid  uint32
@@ -605,6 +423,8 @@ func (cr *CommRecord) read(reader *bytes.Reader) error {
 	return nil
 }
 
+// ExitRecord is a translation of the structure used by the Linux kernel for
+// PERF_RECORD_EXIT samples into Go.
 type ExitRecord struct {
 	Pid  uint32
 	Ppid uint32
@@ -622,8 +442,10 @@ func (er *ExitRecord) read(reader *bytes.Reader) error {
 	return nil
 }
 
+// LostRecord is a translation of the structure used by the Linux kernel for
+// PERF_RECORD_LOST samples into Go.
 type LostRecord struct {
-	Id   uint64
+	ID   uint64
 	Lost uint64
 }
 
@@ -636,6 +458,8 @@ func (lr *LostRecord) read(reader *bytes.Reader) error {
 	return nil
 }
 
+// ForkRecord is a translation of the structure used by the Linux kernel for
+// PERF_RECORD_FORK samples into Go.
 type ForkRecord struct {
 	Pid  uint32
 	Ppid uint32
@@ -762,6 +586,8 @@ func (cg *CounterGroup) read(reader *bytes.Reader, format uint64) error {
 	return nil
 }
 
+// BranchEntry is a translation of the Linux kernel's struct perf_branch_entry
+// into Go. It may appear in SampleRecord if PERF_SAMPLE_BRANCH_STACK is set.
 type BranchEntry struct {
 	From      uint64
 	To        uint64
@@ -772,6 +598,8 @@ type BranchEntry struct {
 	Cycles    uint16
 }
 
+// SampleRecord is a translation of the structure used by the Linux kernel for
+// PERF_RECORD_SAMPLE samples into Go.
 type SampleRecord struct {
 	SampleID    uint64
 	IP          uint64
@@ -932,6 +760,8 @@ func (s *SampleRecord) read(reader *bytes.Reader, eventAttr *EventAttr, formatMa
    };
 */
 
+// SampleID is a translation of the structure used by the Linux kernel for all
+// samples when SampleIDAll is set in the EventAttr used for a sample.
 type SampleID struct {
 	PID      uint32
 	TID      uint32
@@ -1105,6 +935,10 @@ func (sid *SampleID) maybeRead(reader *bytes.Reader, startPos int64, recordSize 
 	return sid.read(reader, eventAttr.SampleType)
 }
 
+// Sample is the representation of a perf_event sample retrieved from the
+// Linux kernel. It includes the header information, a translation of the
+// sample data, and metadata depending on the flags set in the EventAttr
+// used to enable the event that generated the sample.
 type Sample struct {
 	eventHeader
 	Record interface{}


### PR DESCRIPTION
All golint warnings are cleaned up in this PR. Running `make check` yields no warnings or errors.
