### PR TITLE
Apply consistency to network endpoint address naming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,5 @@ LABEL org.label-schema.schema-version="1.0" \
 COPY bin/sensor sensor
 CMD ["/sensor"]
 
-# HTTP Monitoring
-EXPOSE 8080
-
 # For persistent stateful data (e.g. flight recorder event store)
 VOLUME /var/lib/capsule8

--- a/examples/telemetry/main.go
+++ b/examples/telemetry/main.go
@@ -35,14 +35,14 @@ import (
 )
 
 var config struct {
-	endpoint string
-	image    string
+	server string
+	image  string
 }
 
 func init() {
-	flag.StringVar(&config.endpoint, "endpoint",
+	flag.StringVar(&config.server, "server",
 		"unix:/var/run/capsule8/sensor.sock",
-		"Capsule8 gRPC API endpoint")
+		"Capsule8 gRPC API server address")
 
 	flag.StringVar(&config.image, "image", "",
 		"container image wildcard pattern to monitor")
@@ -194,7 +194,7 @@ func main() {
 	flag.Parse()
 
 	// Create telemetry service client
-	conn, err := grpc.Dial(config.endpoint,
+	conn, err := grpc.Dial(config.server,
 		grpc.WithDialer(dialer),
 		grpc.WithInsecure())
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,14 +25,11 @@ var Global struct {
 	RunDir string `split_words:"true" default:"/var/run/capsule8"`
 
 	// HTTP address and port for the pprof runtime profiling endpoint.
-	ProfilingAddr string `split_words:"true"`
+	ProfilingListenAddr string `split_words:"true"`
 }
 
 // Sensor contains overridable configuration options for the sensor
 var Sensor struct {
-	// Node name to use if not the value returned from uname(2)
-	NodeName string
-
 	// DockerContainerDir is the path to the directory used for docker
 	// container local storage areas (i.e. /var/lib/docker/containers)
 	DockerContainerDir string `split_words:"true" default:"/var/lib/docker/containers"`
@@ -42,14 +39,11 @@ var Sensor struct {
 	// (i.e. /var/run/docker/libcontainerd)
 	OciContainerDir string `split_words:"true" default:"/var/run/docker/libcontainerd"`
 
-	// Subscription timeout in seconds
-	SubscriptionTimeout int64 `default:"5"`
-
 	// Sensor gRPC API Server listen address may be specified as any of:
 	//   unix:/path/to/socket
 	//   127.0.0.1:8484
 	//   :8484
-	ServerAddr string `split_words:"true" default:"unix:/var/run/capsule8/sensor.sock"`
+	ListenAddr string `split_words:"true" default:"unix:/var/run/capsule8/sensor.sock"`
 
 	// UseTLS is the boolean switch to enable TLS use. By default it
 	// is false. If UseTLS is true, TLSCACertPath, TLSServerCertPath

--- a/pkg/sensor/main.go
+++ b/pkg/sensor/main.go
@@ -23,12 +23,13 @@ import (
 // Main is the main entrypoint for the sensor
 func Main() {
 	manager := services.NewServiceManager()
-	if len(config.Global.ProfilingAddr) > 0 {
+	if len(config.Global.ProfilingListenAddr) > 0 {
 		service := services.NewProfilingService(
-			config.Global.ProfilingAddr)
+			config.Global.ProfilingListenAddr)
 		manager.RegisterService(service)
 	}
-	if len(config.Sensor.ServerAddr) > 0 {
+
+	if len(config.Sensor.ListenAddr) > 0 {
 		sensor, err := NewSensor()
 		if err != nil {
 			glog.Fatalf("Could not create sensor: %s", err.Error())
@@ -37,7 +38,7 @@ func Main() {
 			glog.Fatalf("Could not start sensor: %s", err.Error())
 		}
 		defer sensor.Stop()
-		service := NewTelemetryService(sensor, config.Sensor.ServerAddr)
+		service := NewTelemetryService(sensor, config.Sensor.ListenAddr)
 		manager.RegisterService(service)
 	}
 


### PR DESCRIPTION
Server code uses variables called `ListenAddr`, client code uses variables called `ServerAddr`. These may be prefixed for clarity. This also modifies the command-line argument in example code to use the `server` argument to match.

Remove unused configuration variables.