### PR TITLE
Add meltdown detector example

### DIFF
--- a/examples/meltdown/Dockerfile
+++ b/examples/meltdown/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+
+COPY meltdown /capsule8-meltdown-detector
+CMD ["/capsule8-meltdown-detector"]

--- a/examples/meltdown/Makefile
+++ b/examples/meltdown/Makefile
@@ -1,0 +1,20 @@
+IMAGE_TAG=getcapsule8/meltdown-detector
+
+.PHONY: all container push run clean
+
+all: container
+
+meltdown: main.go
+	CGO_ENABLED=0 go build .
+
+container: meltdown
+	docker build -t $(IMAGE_TAG) .
+
+push:
+	docker push $(IMAGE_TAG)
+
+run:
+	docker run --cap-add SYS_ADMIN -v /sys/kernel/debug:/sys/kernel/debug:ro $(IMAGE_TAG)
+
+clean:
+	rm meltdown

--- a/examples/meltdown/capsule8-meltdown-detector.yaml
+++ b/examples/meltdown/capsule8-meltdown-detector.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: capsule8-meltdown-detector
+spec:
+  template:
+    metadata:
+      labels:
+        app: capsule8-meltdown-detector
+    spec:
+      containers:
+        - name: capsule8-meltdown-detector
+          image: getcapsule8/meltdown-detector
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+          volumeMounts:
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+              readOnly: true              
+      volumes:
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug

--- a/examples/meltdown/main.go
+++ b/examples/meltdown/main.go
@@ -1,0 +1,132 @@
+// Copyright 2017 Capsule8, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/capsule8/capsule8/pkg/sys/perf"
+	"github.com/golang/glog"
+)
+
+type userPageFault struct {
+	pid       int32
+	ip        uint64
+	address   uint64
+	errorCode uint64
+}
+
+var pageFaultsByPid map[int32]uint
+
+const (
+	alarmThresholdInfo     = 1
+	alarmThresholdLow      = 10
+	alarmThresholdMed      = 100
+	alarmThresholdHigh     = 1000
+	alarmThresholdCritical = 10000
+)
+
+func main() {
+	flag.Set("alsologtostderr", "true")
+	flag.Parse()
+
+	glog.Info("Starting Capsule8 Meltdown Detector")
+
+	monitor, err := perf.NewEventMonitor()
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	//
+	// Look for segmentation faults trying to read kernel memory addresses
+	//
+	filter := "address > 0xffff000000000000"
+	_, err = monitor.RegisterTracepoint("exceptions/page_fault_user",
+		onPageFaultUser, perf.WithFilter(filter))
+
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	pageFaultsByPid = make(map[int32]uint)
+
+	glog.Info("Monitoring for meltdown exploitation attempts")
+	monitor.Run(onSample)
+}
+
+func onSample(eventID uint64, sample interface{}, err error) {
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	upf := sample.(userPageFault)
+
+	glog.V(10).Infof("%+v", sample)
+
+	pageFaultsByPid[upf.pid]++
+
+	faults := pageFaultsByPid[upf.pid]
+	if faults == alarmThresholdInfo {
+		glog.Infof("pid %d kernel address page faults = %d",
+			upf.pid, faults)
+	} else if faults == alarmThresholdLow {
+		glog.Warningf("pid %d kernel address page faults = %d",
+			upf.pid, faults)
+	} else if faults == alarmThresholdMed {
+		glog.Warningf("pid %d kernel address page faults = %d",
+			upf.pid, faults)
+	} else if faults == alarmThresholdHigh {
+		glog.Errorf("pid %d kernel address page faults = %d",
+			upf.pid, faults)
+	} else if faults == alarmThresholdCritical {
+		glog.Errorf("pid %d kernel address page faults = %d",
+			upf.pid, faults)
+	}
+}
+
+func onPageFaultUser(
+	sample *perf.SampleRecord,
+	data perf.TraceEventSampleData,
+) (interface{}, error) {
+	pid, ok := data["common_pid"].(int32)
+	if !ok {
+		return nil, errors.New("common_pid not found")
+	}
+
+	address, ok := data["address"].(uint64)
+	if !ok {
+		return nil, errors.New("address not found")
+	}
+
+	ip, ok := data["ip"].(uint64)
+	if !ok {
+		return nil, errors.New("ip not found")
+	}
+
+	errorCode, ok := data["error_code"].(uint64)
+	if !ok {
+		return nil, errors.New("error_code not found")
+	}
+
+	upf := userPageFault{
+		pid:       pid,
+		ip:        ip,
+		address:   address,
+		errorCode: errorCode,
+	}
+
+	return upf, nil
+}


### PR DESCRIPTION
Sample output:
```
$ sudo ./meltdown
I0105 11:45:54.618781   16452 main.go:46] Starting Capsule8 Meltdown Detector
I0105 11:45:54.710705   16452 main.go:66] Monitoring for meltdown exploitation attempts
I0105 11:46:04.997810   16452 main.go:84] pid 16603 kernel address page faults = 1
W0105 11:46:04.997888   16452 main.go:87] pid 16603 kernel address page faults = 10
W0105 11:46:04.998795   16452 main.go:90] pid 16603 kernel address page faults = 100
E0105 11:46:05.003658   16452 main.go:93] pid 16603 kernel address page faults = 1000
E0105 11:46:05.037321   16452 main.go:96] pid 16603 kernel address page faults = 10000
```  