### PR TITLE
Add cache side channel detector example

### DIFF
--- a/examples/cache-side-channel/main.go
+++ b/examples/cache-side-channel/main.go
@@ -1,0 +1,158 @@
+// Copyright 2017 Capsule8, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"runtime"
+
+	"github.com/capsule8/capsule8/pkg/sys/perf"
+	"github.com/golang/glog"
+)
+
+const (
+	// How many cache loads to sample on. After each sample period
+	// of this many cache loads, the cache miss rate is calculated
+	// and examined. This value tunes the trade-off between CPU
+	// load and detection accuracy.
+	LLCLoadSampleSize = 10000
+
+	// Alarm thresholds as cache miss rates (between 0 and 1).
+	// These values tune the trade-off between false negatives and
+	// false positives.
+	alarmThresholdInfo    = 0.95
+	alarmThresholdWarning = 0.98
+	alarmThresholdError   = 0.99
+
+	// perf_event_attr config value for LL cache loads
+	perfConfigLLCLoads = perf.PERF_COUNT_HW_CACHE_LL |
+		(perf.PERF_COUNT_HW_CACHE_OP_READ << 8) |
+		(perf.PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)
+
+	// perf_event_attr config value for LL cache misses
+	perfConfigLLCLoadMisses = perf.PERF_COUNT_HW_CACHE_LL |
+		(perf.PERF_COUNT_HW_CACHE_OP_READ << 8) |
+		(perf.PERF_COUNT_HW_CACHE_RESULT_MISS << 16)
+)
+
+type eventCounters struct {
+	LLCLoads      uint64
+	LLCLoadMisses uint64
+}
+
+var cpuCounters []eventCounters
+
+func main() {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	glog.Infof("Starting Capsule8 cache side channel detector")
+
+	//
+	// Create our event group to read LL cache accesses and misses
+	//
+	// We ask the kernel to sample every LLCLoadSampleSize LLC
+	// loads. During each sample, the LLC load misses are also
+	// recorded, as well as CPU number, PID/TID, and sample time.
+	//
+	eventGroup := []*perf.EventAttr{}
+
+	ea := &perf.EventAttr{
+		Disabled: true,
+		Type:     perf.PERF_TYPE_HW_CACHE,
+		Config:   perfConfigLLCLoads,
+		SampleType: perf.PERF_SAMPLE_CPU | perf.PERF_SAMPLE_STREAM_ID |
+			perf.PERF_SAMPLE_TID | perf.PERF_SAMPLE_READ | perf.PERF_SAMPLE_TIME,
+		ReadFormat:   perf.PERF_FORMAT_GROUP | perf.PERF_FORMAT_ID,
+		Pinned:       true,
+		Exclusive:    true,
+		SamplePeriod: LLCLoadSampleSize,
+		WakeupEvents: 1,
+	}
+	eventGroup = append(eventGroup, ea)
+
+	ea = &perf.EventAttr{
+		Disabled: true,
+		Type:     perf.PERF_TYPE_HW_CACHE,
+		Config:   perfConfigLLCLoadMisses,
+	}
+	eventGroup = append(eventGroup, ea)
+
+	eg, err := perf.NewEventGroup(eventGroup)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	//
+	// Open the event group on all CPUs
+	//
+	err = eg.Open()
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	// Allocate counters per CPU
+	cpuCounters = make([]eventCounters, runtime.NumCPU())
+
+	glog.Info("Monitoring for cache side channels")
+	eg.Run(func(sample perf.Sample) {
+		sr, ok := sample.Record.(*perf.SampleRecord)
+		if ok {
+			onSample(sr, eg.EventAttrsByID)
+		}
+	})
+}
+
+func onSample(sr *perf.SampleRecord, eventAttrMap map[uint64]*perf.EventAttr) {
+	var counters eventCounters
+
+	// The sample record contains all values in the event group,
+	// tagged with their event ID
+	for _, v := range sr.V.Values {
+		ea := eventAttrMap[v.ID]
+
+		if ea.Config == perfConfigLLCLoads {
+			counters.LLCLoads = v.Value
+		} else if ea.Config == perfConfigLLCLoadMisses {
+			counters.LLCLoadMisses = v.Value
+		}
+	}
+
+	cpu := sr.CPU
+	prevCounters := cpuCounters[cpu]
+	cpuCounters[cpu] = counters
+
+	counterDeltas := eventCounters{
+		LLCLoads:      counters.LLCLoads - prevCounters.LLCLoads,
+		LLCLoadMisses: counters.LLCLoadMisses - prevCounters.LLCLoadMisses,
+	}
+
+	alarm(sr, counterDeltas)
+}
+
+func alarm(sr *perf.SampleRecord, counters eventCounters) {
+	LLCLoadMissRate := float32(counters.LLCLoadMisses) / float32(counters.LLCLoads)
+
+	if LLCLoadMissRate > alarmThresholdError {
+		glog.Errorf("cpu=%v pid=%v tid=%v LLCLoadMissRate=%v",
+			sr.CPU, sr.Pid, sr.Tid, LLCLoadMissRate)
+	} else if LLCLoadMissRate > alarmThresholdWarning {
+		glog.Warningf("cpu=%v pid=%v tid=%v LLCLoadMissRate=%v",
+			sr.CPU, sr.Pid, sr.Tid, LLCLoadMissRate)
+	} else if LLCLoadMissRate > alarmThresholdInfo {
+		glog.Infof("cpu=%v pid=%v tid=%v LLCLoadMissRate=%v",
+			sr.CPU, sr.Pid, sr.Tid, LLCLoadMissRate)
+	}
+}

--- a/pkg/sys/perf/event_group.go
+++ b/pkg/sys/perf/event_group.go
@@ -1,0 +1,140 @@
+// Copyright 2017 Capsule8, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perf
+
+import (
+	"bytes"
+	"runtime"
+
+	"github.com/golang/glog"
+	"golang.org/x/sys/unix"
+)
+
+type EventGroup struct {
+	eventAttrs []*EventAttr
+	options    eventMonitorOptions
+
+	fds      []int
+	groupFds []int
+
+	EventAttrsByID eventAttrMap
+	ringBuffers    []*ringBuffer
+	onSample       func(Sample)
+}
+
+func NewEventGroup(eventAttrs []*EventAttr, options ...EventMonitorOption) (*EventGroup, error) {
+	eg := EventGroup{}
+	eg.eventAttrs = eventAttrs
+
+	for _, o := range options {
+		o(&eg.options)
+	}
+
+	return &eg, nil
+}
+
+func (eg *EventGroup) Open() error {
+	ncpu := runtime.NumCPU()
+
+	// Create format map
+	eg.EventAttrsByID = newEventAttrMap()
+
+	eg.groupFds = make([]int, ncpu)
+
+	for cpu := 0; cpu < ncpu; cpu++ {
+		eg.groupFds[cpu] = int(-1)
+
+		for _, ea := range eg.eventAttrs {
+			flags := eg.options.flags | PERF_FLAG_FD_CLOEXEC
+
+			// Fixup
+			ea.Size = sizeofPerfEventAttrVer5
+			ea.SampleType |= PERF_SAMPLE_CPU | PERF_SAMPLE_STREAM_ID | PERF_SAMPLE_IDENTIFIER | PERF_SAMPLE_TIME
+			fd, err := open(ea, -1, cpu, eg.groupFds[cpu], flags)
+			if err != nil {
+				glog.Fatal(err)
+			}
+
+			streamID, err := unix.IoctlGetInt(fd, PERF_EVENT_IOC_ID)
+			if err != nil {
+				glog.Fatal(err)
+			}
+
+			eg.EventAttrsByID[uint64(streamID)] = ea
+
+			eg.fds = append(eg.fds, fd)
+
+			if eg.groupFds[cpu] < 0 {
+				// NB: We must open ring buffer before we can redirect output to it
+				rb, err := newRingBuffer(fd, eg.options.ringBufferNumPages)
+				if err != nil {
+					glog.Fatal(err)
+				}
+
+				eg.ringBuffers = append(eg.ringBuffers, rb)
+
+				eg.groupFds[cpu] = fd
+			}
+		}
+	}
+
+	return nil
+}
+
+func (eg *EventGroup) Run(onSample func(Sample)) error {
+	eg.onSample = onSample
+
+	pollFds := make([]unix.PollFd, len(eg.groupFds))
+
+	// Enable all events
+	for i, fd := range eg.groupFds {
+		err := enable(fd)
+		if err != nil {
+			glog.Fatal(err)
+		}
+
+		pollFds[i].Fd = int32(fd)
+		pollFds[i].Events = unix.POLLIN
+	}
+
+	for {
+		n, err := unix.Poll(pollFds, -1)
+		if err != nil && err != unix.EINTR {
+			return err
+		}
+
+		if n > 0 {
+			for i, fd := range pollFds {
+				if (fd.Revents & unix.POLLIN) != 0 {
+					eg.ringBuffers[i].read(eg.readSample)
+				}
+			}
+		}
+	}
+}
+
+func (eg *EventGroup) readSample(data []byte) {
+	reader := bytes.NewReader(data)
+	sample := &Sample{}
+
+	err := sample.read(reader, nil, eg.EventAttrsByID)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	if eg.onSample != nil {
+		eg.onSample(*sample)
+	}
+}

--- a/pkg/sys/perf/types.go
+++ b/pkg/sys/perf/types.go
@@ -528,8 +528,6 @@ func (cg *CounterGroup) read(reader *bytes.Reader, format uint64) error {
 			}
 		}
 
-		var values []CounterValue
-
 		for i := uint64(0); i < nr; i++ {
 			value := CounterValue{}
 			err = binary.Read(reader, binary.LittleEndian,
@@ -546,7 +544,7 @@ func (cg *CounterGroup) read(reader *bytes.Reader, format uint64) error {
 				}
 			}
 
-			values = append(values, value)
+			cg.Values = append(cg.Values, value)
 		}
 
 		return nil


### PR DESCRIPTION
Implement cache side channel detector example to measure cache miss rate based on a period of cache loads. This can be useful to detect exploitation of the Meltdown and Spectre vulnerabilities.

Add a lower-level interface to `pkg/sys/perf` called `perf.EventGroup`.

  