### PR TITLE
Add go_package option to proto files

### DIFF
--- a/api/v0/expression.proto
+++ b/api/v0/expression.proto
@@ -18,6 +18,8 @@ package capsule8.api.v0;
 
 import "google/protobuf/timestamp.proto";
 
+option go_package = "github.com/capsule8/capsule8/api/v0";
+
 enum ValueType {
         VALUETYPE_UNSPECIFIED = 0;
 

--- a/api/v0/subscription.proto
+++ b/api/v0/subscription.proto
@@ -20,6 +20,8 @@ import "capsule8/api/v0/telemetry_event.proto";
 import "capsule8/api/v0/expression.proto";
 import "google/protobuf/wrappers.proto";
 
+option go_package = "github.com/capsule8/capsule8/api/v0";
+
 //
 // The Subscription message identifies a subscriber's interest in
 // telemetry events.

--- a/api/v0/telemetry_event.proto
+++ b/api/v0/telemetry_event.proto
@@ -18,6 +18,8 @@ package capsule8.api.v0;
 
 import "capsule8/api/v0/types.proto";
 
+option go_package = "github.com/capsule8/capsule8/api/v0";
+
 // An event observed by the Sensor.
 message TelemetryEvent {
         // Unique identifier for the event

--- a/api/v0/telemetry_service.proto
+++ b/api/v0/telemetry_service.proto
@@ -23,6 +23,8 @@ import "capsule8/api/v0/subscription.proto";
 import "capsule8/api/v0/telemetry_event.proto";
 import "google/api/annotations.proto";
 
+option go_package = "github.com/capsule8/capsule8/api/v0";
+
 //
 // Capsule8 Telemetry API
 //

--- a/api/v0/types.proto
+++ b/api/v0/types.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package capsule8.api.v0;
 
+option go_package = "github.com/capsule8/capsule8/api/v0";
+
 // Supported network address families
 enum NetworkAddressFamily {
         // The network address family is unknown


### PR DESCRIPTION
Without the go_package option set the compiled protos in repositories that import this one will not use a valid go import path. This option is set in the [Makefile](https://github.com/capsule8/capsule8/blob/master/Makefile#L52) but that's only used locally. 

Signed-off-by: grant <grant@capsule8.com>

