### PR TITLE
Perf event attr exclusive fails silently on most distro kernels, don't use it.

### DIFF
--- a/examples/cache-side-channel/main.go
+++ b/examples/cache-side-channel/main.go
@@ -32,7 +32,7 @@ const (
 	// Alarm thresholds as cache miss rates (between 0 and 1).
 	// These values tune the trade-off between false negatives and
 	// false positives.
-	alarmThresholdInfo    = 0.95
+	alarmThresholdInfo    = 0.97
 	alarmThresholdWarning = 0.98
 	alarmThresholdError   = 0.99
 
@@ -77,7 +77,6 @@ func main() {
 			perf.PERF_SAMPLE_TID | perf.PERF_SAMPLE_READ | perf.PERF_SAMPLE_TIME,
 		ReadFormat:   perf.PERF_FORMAT_GROUP | perf.PERF_FORMAT_ID,
 		Pinned:       true,
-		Exclusive:    true,
 		SamplePeriod: LLCLoadSampleSize,
 		WakeupEvents: 1,
 	}


### PR DESCRIPTION
The important bit in [`perf_event_open(2)`](http://man7.org/linux/man-pages/man2/perf_event_open.2.html):
```
Note  that  many unexpected situations may prevent events with the exclusive bit set from
ever running.  This includes any users running a system-wide measurement as well  as  any
kernel use of the performance counters (including the commonly enabled NMI Watchdog Timer
interface).
```

Most distributions kernels (Ubuntu and Fedora tested so far) seem to use the NMI Watchdog Timer, so setting this bit means that no events will ever be triggered and make the detector do nothing.

After testing on i5-class processors, an "info" threshold of 0.95 is a bit too low, increment this to 0.97.