### PR TITLE
Change expression.FieldTypeMap to map[string]int32

### DIFF
--- a/pkg/expression/evaluate.go
+++ b/pkg/expression/evaluate.go
@@ -26,7 +26,7 @@ import (
 )
 
 // nullValueType is only used internally
-const nullValueType api.ValueType = api.ValueType_VALUETYPE_UNSPECIFIED
+const nullValueType = api.ValueType_VALUETYPE_UNSPECIFIED
 
 func timestampValue(stamp *google_protobuf2.Timestamp) uint64 {
 	return (uint64(stamp.Seconds) * uint64(time.Second)) +
@@ -212,19 +212,19 @@ type evalContext struct {
 	stack  []api.Value
 }
 
-var typeStrings = map[api.ValueType]string{
-	api.ValueType_STRING:    "string",
-	api.ValueType_SINT8:     "int8",
-	api.ValueType_SINT16:    "int16",
-	api.ValueType_SINT32:    "int32",
-	api.ValueType_SINT64:    "int64",
-	api.ValueType_UINT8:     "uint8",
-	api.ValueType_UINT16:    "uint16",
-	api.ValueType_UINT32:    "uint32",
-	api.ValueType_UINT64:    "uint64",
-	api.ValueType_BOOL:      "bool",
-	api.ValueType_DOUBLE:    "float64",
-	api.ValueType_TIMESTAMP: "uint64",
+var typeStrings = map[int32]string{
+	int32(api.ValueType_STRING):    "string",
+	int32(api.ValueType_SINT8):     "int8",
+	int32(api.ValueType_SINT16):    "int16",
+	int32(api.ValueType_SINT32):    "int32",
+	int32(api.ValueType_SINT64):    "int64",
+	int32(api.ValueType_UINT8):     "uint8",
+	int32(api.ValueType_UINT16):    "uint16",
+	int32(api.ValueType_UINT32):    "uint32",
+	int32(api.ValueType_UINT64):    "uint64",
+	int32(api.ValueType_BOOL):      "bool",
+	int32(api.ValueType_DOUBLE):    "float64",
+	int32(api.ValueType_TIMESTAMP): "uint64",
 }
 
 func (c *evalContext) pushIdentifier(ident string) error {
@@ -234,17 +234,17 @@ func (c *evalContext) pushIdentifier(ident string) error {
 	}
 	v, ok := c.values[ident]
 	if !ok {
-		t = nullValueType
+		t = int32(nullValueType)
 	} else if reflect.TypeOf(v).String() != typeStrings[t] {
 		return fmt.Errorf("Data type mismatch for %q (expected %s; got %s)",
 			ident, typeStrings[t], reflect.TypeOf(v))
 	}
 
 	value := api.Value{
-		Type: t,
+		Type: api.ValueType(t),
 	}
 
-	switch t {
+	switch value.Type {
 	case api.ValueType_STRING:
 		value.Value = &api.Value_StringValue{StringValue: v.(string)}
 	case api.ValueType_SINT8:

--- a/pkg/expression/evaluate_test.go
+++ b/pkg/expression/evaluate_test.go
@@ -52,12 +52,12 @@ func TestExpressionEvaluation(t *testing.T) {
 	var expr *api.Expression
 
 	types := FieldTypeMap{
-		"port":     api.ValueType_UINT16,
-		"address":  api.ValueType_STRING,
-		"flags":    api.ValueType_UINT32,
-		"filename": api.ValueType_STRING,
-		"path":     api.ValueType_STRING,
-		"service":  api.ValueType_STRING,
+		"port":     int32(api.ValueType_UINT16),
+		"address":  int32(api.ValueType_STRING),
+		"flags":    int32(api.ValueType_UINT32),
+		"filename": int32(api.ValueType_STRING),
+		"path":     int32(api.ValueType_STRING),
+		"service":  int32(api.ValueType_STRING),
 	}
 
 	values := FieldValueMap{

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -19,7 +19,7 @@ import (
 )
 
 // FieldTypeMap is a mapping of types for field names/identifiers
-type FieldTypeMap map[string]api.ValueType
+type FieldTypeMap map[string]int32
 
 // FieldValueMap is a mapping of values for field names/identifiers.
 type FieldValueMap map[string]interface{}

--- a/pkg/expression/validate.go
+++ b/pkg/expression/validate.go
@@ -326,7 +326,7 @@ func validateTypes(expr *api.Expression, types FieldTypeMap) (api.ValueType, err
 		if !ok {
 			return 0, fmt.Errorf("Undefined identifier %q", ident)
 		}
-		return t, nil
+		return api.ValueType(t), nil
 	case api.Expression_VALUE:
 		return expr.GetValue().GetType(), nil
 	case api.Expression_LOGICAL_AND, api.Expression_LOGICAL_OR:

--- a/pkg/expression/validate_test.go
+++ b/pkg/expression/validate_test.go
@@ -134,12 +134,12 @@ func TestExpressionValidation(t *testing.T) {
 	var expr *api.Expression
 
 	types := FieldTypeMap{
-		"port":     api.ValueType_UINT16,
-		"filename": api.ValueType_STRING,
-		"path":     api.ValueType_STRING,
-		"service":  api.ValueType_STRING,
-		"address":  api.ValueType_STRING,
-		"flags":    api.ValueType_UINT32,
+		"port":     int32(api.ValueType_UINT16),
+		"filename": int32(api.ValueType_STRING),
+		"path":     int32(api.ValueType_STRING),
+		"service":  int32(api.ValueType_STRING),
+		"address":  int32(api.ValueType_STRING),
+		"flags":    int32(api.ValueType_UINT32),
 	}
 
 	var binaryOps = []api.Expression_ExpressionType{

--- a/pkg/sensor/container.go
+++ b/pkg/sensor/container.go
@@ -28,14 +28,14 @@ import (
 )
 
 var containerEventTypes = expression.FieldTypeMap{
-	"name":             api.ValueType_STRING,
-	"image_id":         api.ValueType_STRING,
-	"image_name":       api.ValueType_STRING,
-	"host_pid":         api.ValueType_SINT32,
-	"exit_code":        api.ValueType_SINT32,
-	"exit_status":      api.ValueType_UINT32,
-	"exit_signal":      api.ValueType_UINT32,
-	"exit_core_dumped": api.ValueType_BOOL,
+	"name":             int32(api.ValueType_STRING),
+	"image_id":         int32(api.ValueType_STRING),
+	"image_name":       int32(api.ValueType_STRING),
+	"host_pid":         int32(api.ValueType_SINT32),
+	"exit_code":        int32(api.ValueType_SINT32),
+	"exit_status":      int32(api.ValueType_UINT32),
+	"exit_signal":      int32(api.ValueType_UINT32),
+	"exit_core_dumped": int32(api.ValueType_BOOL),
 }
 
 type containerEventRepeater struct {


### PR DESCRIPTION
Due to issues with type conversions (specifically, Go's lack of support for recursive type conversions), it's easiest if the public API for the expression engine uses `int32` instead of `api.ValueType` (even though they can be converted; protobuf defines `api.ValueType` as `int32`) instead of `api.ValueType`. This removes the need for making copies to perform the conversion or to introduce otherwise unnecessary dependencies.