### PR TITLE
Don't wait for telemetry clients to finish before stopping

### DIFF
--- a/pkg/sensor/telemetry.go
+++ b/pkg/sensor/telemetry.go
@@ -149,7 +149,7 @@ func (ts *TelemetryService) Serve() error {
 
 // Stop will stop a running TelemetryService.
 func (ts *TelemetryService) Stop() {
-	ts.server.GracefulStop()
+	ts.server.Stop()
 }
 
 type telemetryServiceServer struct {


### PR DESCRIPTION
- Telemetry clients open streaming connections, waiting for them to finish causes the service manager to hang when attempting to stop all services
- `GracefulStop` in grpc-go `1.7.x` didn't actually work, it would block on a condition variable used to wait for all connections but wouldn't actually block the stoppage of the grpc server itself. This is a bug on their end that was fixed by `1.9.x` causing the hanging behaviour to surface on our end.