### PR TITLE
make Sensor.processCache public to expose its public methods

### DIFF
--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -49,7 +49,7 @@ func (f *processFilter) decodeSchedProcessFork(sample *perf.SampleRecord, data p
 		},
 	}
 
-	if _, l, _ := f.sensor.processCache.LookupTaskAndLeader(int(childPid)); l != nil {
+	if _, l, _ := f.sensor.ProcessCache.LookupTaskAndLeader(int(childPid)); l != nil {
 		ev.GetProcess().ForkChildId = l.ProcessID()
 	}
 
@@ -63,7 +63,7 @@ func (f *processFilter) decodeSchedProcessExec(sample *perf.SampleRecord, data p
 	// Get the command-line from the process info cache. If it's not there
 	// for whatever reason, fallback to using procfs
 	var commandLine []string
-	_, l, _ := f.sensor.processCache.LookupTaskAndLeader(int(hostPid))
+	_, l, _ := f.sensor.ProcessCache.LookupTaskAndLeader(int(hostPid))
 	if l == nil || l.CommandLine == nil || len(l.CommandLine) == 0 {
 		commandLine = sys.HostProcFS().CommandLine(int(hostPid))
 	} else {

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -67,7 +67,7 @@ type Sensor struct {
 
 	// Per-sensor caches and monitors
 	containerCache *containerCache
-	processCache   ProcessInfoCache
+	ProcessCache   ProcessInfoCache
 	dockerMonitor  *dockerMonitor
 	ociMonitor     *ociMonitor
 
@@ -146,7 +146,7 @@ func (s *Sensor) Start() error {
 	}
 
 	s.containerCache = newContainerCache(s)
-	s.processCache = newProcessInfoCache(s)
+	s.ProcessCache = newProcessInfoCache(s)
 
 	if len(config.Sensor.DockerContainerDir) > 0 {
 		s.dockerMonitor = newDockerMonitor(s,
@@ -320,7 +320,7 @@ func (s *Sensor) NewEventFromSample(
 	e.Cpu = int32(sample.CPU)
 
 	pid := int(e.ProcessPid)
-	if task, leader, ok := s.processCache.LookupTaskAndLeader(pid); ok {
+	if task, leader, ok := s.ProcessCache.LookupTaskAndLeader(pid); ok {
 		e.ProcessId = leader.ProcessID()
 		if c := task.Creds; c != nil {
 			e.Credentials = &api.Credentials{
@@ -335,7 +335,7 @@ func (s *Sensor) NewEventFromSample(
 			}
 		}
 
-		if i := s.processCache.LookupTaskContainerInfo(leader); i != nil {
+		if i := s.ProcessCache.LookupTaskContainerInfo(leader); i != nil {
 			e.ContainerId = i.ID
 			e.ContainerName = i.Name
 			e.ImageId = i.ImageID


### PR DESCRIPTION
Fixes https://github.com/capsule8/capsule8/issues/119

Making `Sensor.processCache` public exposes these public methods:

```
type ProcessInfoCache
    func (pc *ProcessInfoCache) ProcessCommandLine(pid int) ([]string, bool)
    func (pc *ProcessInfoCache) ProcessContainerID(pid int) (string, bool)
    func (pc *ProcessInfoCache) ProcessContainerInfo(pid int) (*ContainerInfo, bool)
    func (pc *ProcessInfoCache) ProcessCredentials(pid int, c *Cred) bool
    func (pc *ProcessInfoCache) ProcessID(pid int) (string, bool)
```