### PR TITLE
Update the process cache API to be more friendly to lookups

### DIFF
--- a/pkg/sensor/process_info.go
+++ b/pkg/sensor/process_info.go
@@ -14,21 +14,21 @@
 
 package sensor
 
-//
 // This file implements a process information cache that uses a sensor's
 // system-global EventMonitor to keep it up-to-date. The cache also monitors
 // for runc container starts to identify the containerID for a given PID
 // namespace. Process information gathered by the cache may be retrieved via
-// the ProcessID and ProcessContainerID methods.
+// the LookupTask and LookupTaskAndLeader methods.
 //
 // glog levels used:
 //   10 = cache operation level tracing for debugging
-//
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/capsule8/capsule8/pkg/config"
 	"github.com/capsule8/capsule8/pkg/sys"
@@ -59,181 +59,278 @@ var (
 	once   sync.Once
 )
 
+// Task represents a schedulable task. All Linux tasks are uniquely identified
+// at a given time by their PID, but those PIDs may be reused after hitting the
+// maximum PID value.
+type Task struct {
+	// PID is the kernel's internal process identifier, which is equivalent
+	// to the TID in userspace.
+	PID int
+
+	// TGID is the kernel's internal thread group identifier, which is
+	// equivalent to the PID in userspace. All threads within a process
+	// have differing PIDs, but all share the same TGID. The thread group
+	// leader process's PID will be the same as its TGID.
+	TGID int
+
+	// PPID is the parent PID of the originating parent process vs. current
+	// parent in case the parent terminates and the child is reparented
+	// (usually to init).
+	PPID int
+
+	// Command is the kernel's comm field, which is initialized to the
+	// first 15 characters of the basename of the executable being run.
+	// It is also set via pthread_setname_np(3) and prctl(2) PR_SET_NAME.
+	// It is always NULL-terminated and no longer than 16 bytes (including
+	// NUL byte).
+	Command string
+
+	// CommandLine is the command-line used when the process was exec'd via
+	// execve(). It is composed of the first 6 elements of argv. It may
+	// not be complete if argv contained more than 6 elements.
+	CommandLine []string
+
+	// Creds are the credentials (uid, gid) for the task. This is kept
+	// up-to-date by recording changes observed via a kprobe on
+	// commit_creds().
+	Creds *Cred
+
+	// ContainerID is the ID of the container to which the task belongs,
+	// if any.
+	ContainerID string
+
+	// ContainerInfo is a pointer to the cached container information for
+	// the container to which the task belongs, if any.
+	ContainerInfo *ContainerInfo
+
+	// processID is a cached unique ID for the process.
+	processID string
+}
+
+// Cred contains task credential information
+type Cred struct {
+	// UID is the real UID
+	UID uint32
+	// GID is the real GID
+	GID uint32
+	// EUID is the effective UID
+	EUID uint32
+	// EGID is the effective GID
+	EGID uint32
+	// SUID is the saved UID
+	SUID uint32
+	// SGID is the saved GID
+	SGID uint32
+	// FSUID is the UID for filesystem operations
+	FSUID uint32
+	// FSGID is the GID for filesystem operations
+	FSGID uint32
+}
+
+// IsValid returns true if the task instance is valid. A valid task instance
+// has both PID and TGID fields >= 0.
+func (t *Task) IsValid() bool {
+	return t.PID > 0 && t.TGID > 0
+}
+
+// Invalidate invalidates a task instance.
+func (t *Task) Invalidate() {
+	t.PID = 0
+	t.TGID = 0
+
+	// Clear references for GC
+	t.Command = ""
+	t.CommandLine = nil
+	t.ContainerID = ""
+	t.ContainerInfo = nil
+	t.Creds = nil
+	t.processID = ""
+}
+
+// ProcessID returns the unique ID for a task. Normally this is used on the
+// thread group leader for a process. The process ID is identical whether it
+// is derived inside or outside a container.
+func (t *Task) ProcessID() string {
+	if t.processID == "" {
+		t.processID = proc.DeriveUniqueID(t.PID, t.PPID)
+	}
+	return t.processID
+}
+
+// Update updates a task instance with new data. It returns true if any data
+// was actually changed.
+func (t *Task) Update(data map[string]interface{}) bool {
+	dataChanged := false
+	changedContainerInfo := false
+
+	s := reflect.ValueOf(t).Elem()
+	st := s.Type()
+	for i := st.NumField() - 1; i >= 0; i-- {
+		f := st.Field(i)
+		if !unicode.IsUpper(rune(f.Name[0])) {
+			continue
+		}
+		v, ok := data[f.Name]
+		if !ok {
+			continue
+		}
+		if !reflect.TypeOf(v).AssignableTo(f.Type) {
+			glog.Fatalf("Cannot assign %v to %s %",
+				v, f.Name, f.Type)
+		}
+
+		// Assume field types that are not compareable always change
+		// Examples of uncompareable types: []string (e.g. CommandLine)
+		if !reflect.TypeOf(v).Comparable() ||
+			s.Field(i).Interface() != v {
+			dataChanged = true
+			s.Field(i).Set(reflect.ValueOf(v))
+
+			switch f.Name {
+			case "PID", "PPID":
+				// The cached processID depends on PID and PPID.
+				// If either changes, invalidate the cached
+				// value.
+				t.processID = ""
+			case "ContainerID":
+				// Invalidate ContainerInfo if it hasn't
+				// already been changed in this update.
+				if !changedContainerInfo {
+					t.ContainerInfo = nil
+				}
+			case "ContainerInfo":
+				changedContainerInfo = true
+			}
+		}
+	}
+
+	return dataChanged
+}
+
 type taskCache interface {
-	LookupTask(int, *task) bool
-	LookupLeader(int) (task, bool)
-	InsertTask(int, task)
-	SetTaskContainerID(int, string)
-	SetTaskContainerInfo(int, *ContainerInfo)
-	SetTaskCredentials(int, Cred)
-	SetTaskCommandLine(int, []string)
+	LookupTask(int) (*Task, bool)
+	LookupTaskAndLeader(int) (*Task, *Task, bool)
+	InsertTask(int, *Task)
+	DeleteTask(int)
 }
 
 type arrayTaskCache struct {
-	entries []task
+	entries []Task
 }
 
 func newArrayTaskCache(size uint) *arrayTaskCache {
 	return &arrayTaskCache{
-		entries: make([]task, size),
+		entries: make([]Task, size),
 	}
 }
 
-func (c *arrayTaskCache) LookupTask(pid int, t *task) bool {
-	*t = c.entries[pid]
-	ok := t.tgid != 0
-
-	if ok {
-		glog.V(10).Infof("LookupTask(%d) -> %+v", pid, t)
-	} else {
+func (c *arrayTaskCache) LookupTask(pid int) (*Task, bool) {
+	t := &c.entries[pid]
+	if !t.IsValid() {
 		glog.V(10).Infof("LookupTask(%d) -> nil", pid)
+		return nil, false
 	}
-
-	return ok
+	glog.V(10).Infof("LookupTask(%d) -> %+v", pid, t)
+	return t, true
 }
 
-func (c *arrayTaskCache) LookupLeader(pid int) (task, bool) {
-	var t task
-
-	if c.LookupTask(pid, &t) &&
-		(pid == t.tgid || c.LookupTask(t.tgid, &t)) {
-		return t, true
+func (c *arrayTaskCache) LookupTaskAndLeader(pid int) (*Task, *Task, bool) {
+	t, ok := c.LookupTask(pid)
+	if ok {
+		if pid != t.TGID {
+			leader, ok := c.LookupTask(t.TGID)
+			return t, leader, ok
+		}
+		return t, t, true
 	}
-
-	return task{}, false
+	return nil, nil, false
 }
 
-func (c *arrayTaskCache) InsertTask(pid int, t task) {
+func (c *arrayTaskCache) InsertTask(pid int, t *Task) {
 	glog.V(10).Infof("InsertTask(%d, %+v)", pid, t)
-	c.entries[pid] = t
-}
-
-func (c *arrayTaskCache) SetTaskContainerID(pid int, cID string) {
-	glog.V(10).Infof("SetTaskContainerID(%d) = %s", pid, cID)
-	if c.entries[pid].containerID != cID {
-		c.entries[pid].containerID = cID
-		c.entries[pid].containerInfo = nil
+	if pid <= 0 || !t.IsValid() {
+		glog.Fatalf("Invalid task for pid %d: %+v", pid, t)
 	}
+	c.entries[pid] = *t
 }
 
-func (c *arrayTaskCache) SetTaskContainerInfo(pid int, info *ContainerInfo) {
-	glog.V(10).Infof("SetTaskContainerInfo(ID(%d) = %+v", pid, info)
-	if c.entries[pid].containerInfo != info {
-		c.entries[pid].containerID = info.ID
-		c.entries[pid].containerInfo = info
-	}
-}
-
-func (c *arrayTaskCache) SetTaskCredentials(pid int, creds Cred) {
-	glog.V(10).Infof("SetTaskCredentials(%d) = %+v", pid, creds)
-
-	c.entries[pid].creds = creds
-}
-
-func (c *arrayTaskCache) SetTaskCommandLine(pid int, commandLine []string) {
-	glog.V(10).Infof("SetTaskCommandLine(%d) = %s", pid, commandLine)
-	c.entries[pid].commandLine = commandLine
+func (c *arrayTaskCache) DeleteTask(pid int) {
+	glog.V(10).Infof("DeleteTask(%d)", pid)
+	c.entries[pid].Invalidate()
 }
 
 type mapTaskCache struct {
 	sync.Mutex
-	entries map[int]task
+	entries map[int]*Task
 }
 
-func newMapTaskCache() *mapTaskCache {
+func newMapTaskCache(size uint) *mapTaskCache {
+	// The size here is likely to be quite large, so we don't really want
+	// to size the map to it initially. On the other hand, we don't want
+	// to let the map grow naturally using Go defaults, because we assume
+	// that we will have a fairly large number of tasks.
 	return &mapTaskCache{
-		entries: make(map[int]task),
+		entries: make(map[int]*Task, size/4),
 	}
 }
 
-func (c *mapTaskCache) lookupTaskUnlocked(pid int, t *task) (ok bool) {
-	*t, ok = c.entries[pid]
-	ok = ok && t.tgid != 0
-
-	if ok {
-		glog.V(10).Infof("LookupTask(%d) -> %+v", pid, t)
-	} else {
+func (c *mapTaskCache) lookupTaskUnlocked(pid int) (*Task, bool) {
+	t, ok := c.entries[pid]
+	if !ok {
 		glog.V(10).Infof("LookupTask(%d) -> nil", pid)
+		return nil, false
+	}
+	if !t.IsValid() {
+		glog.Fatalf("Found invalid task in cache for pid %d: %+v",
+			pid, t)
 	}
 
-	return ok
+	glog.V(10).Infof("LookupTask(%d) -> %+v", pid, t)
+	return t, true
 }
 
-func (c *mapTaskCache) LookupTask(pid int, t *task) bool {
+func (c *mapTaskCache) LookupTask(pid int) (*Task, bool) {
 	c.Lock()
-	defer c.Unlock()
-	return c.lookupTaskUnlocked(pid, t)
+	t, ok := c.lookupTaskUnlocked(pid)
+	c.Unlock()
+
+	return t, ok
 }
 
-func (c *mapTaskCache) LookupLeader(pid int) (task, bool) {
+func (c *mapTaskCache) LookupTaskAndLeader(pid int) (*Task, *Task, bool) {
 	c.Lock()
-	defer c.Unlock()
-
-	var t task
-
-	if c.lookupTaskUnlocked(pid, &t) &&
-		(pid == t.tgid || c.lookupTaskUnlocked(t.tgid, &t)) {
-		return t, true
+	t, ok := c.lookupTaskUnlocked(pid)
+	if ok {
+		if pid != t.TGID {
+			leader, ok := c.lookupTaskUnlocked(t.TGID)
+			return t, leader, ok
+		}
+		c.Unlock()
+		return t, t, true
 	}
-
-	return task{}, false
+	c.Unlock()
+	return nil, nil, false
 }
 
-func (c *mapTaskCache) InsertTask(pid int, t task) {
+func (c *mapTaskCache) InsertTask(pid int, t *Task) {
 	glog.V(10).Infof("InsertTask(%d, %+v)", pid, t)
+	if pid <= 0 || !t.IsValid() {
+		glog.Fatalf("Invalid task for pid %d: %+v", pid, t)
+	}
+
+	taskCopy := *t
 
 	c.Lock()
-	defer c.Unlock()
-
-	c.entries[pid] = t
+	c.entries[pid] = &taskCopy
+	c.Unlock()
 }
 
-func (c *mapTaskCache) SetTaskContainerID(pid int, cID string) {
-	glog.V(10).Infof("SetTaskContainerID(%d) = %s", pid, cID)
+func (c *mapTaskCache) DeleteTask(pid int) {
+	glog.V(10).Infof("DeleteTask(%d)", pid)
 
 	c.Lock()
-	defer c.Unlock()
-	if t, ok := c.entries[pid]; ok && t.containerID != cID {
-		t.containerID = cID
-		t.containerInfo = nil
-		c.entries[pid] = t
-	}
-}
-
-func (c *mapTaskCache) SetTaskContainerInfo(pid int, info *ContainerInfo) {
-	glog.V(10).Infof("SetTaskContainerInfo(%d) = %+v", pid, info)
-
-	c.Lock()
-	defer c.Unlock()
-	if t, ok := c.entries[pid]; ok && t.containerInfo != info {
-		t.containerID = info.ID
-		t.containerInfo = info
-		c.entries[pid] = t
-	}
-}
-
-func (c *mapTaskCache) SetTaskCredentials(pid int, creds Cred) {
-	glog.V(10).Infof("SetTaskCredentials(%d) = %+v", pid, creds)
-
-	c.Lock()
-	defer c.Unlock()
-	t, ok := c.entries[pid]
-	if ok {
-		t.creds = creds
-		c.entries[pid] = t
-	}
-}
-
-func (c *mapTaskCache) SetTaskCommandLine(pid int, commandLine []string) {
-	glog.V(10).Infof("SetTaskCommandLine(%d) = %s", pid, commandLine)
-
-	c.Lock()
-	defer c.Unlock()
-	t, ok := c.entries[pid]
-	if ok {
-		t.commandLine = commandLine
-		c.entries[pid] = t
-	}
+	delete(c.entries, pid)
+	c.Unlock()
 }
 
 // ProcessInfoCache is an object that caches process information. It is
@@ -260,7 +357,7 @@ func newProcessInfoCache(sensor *Sensor) ProcessInfoCache {
 
 	maxPid := proc.MaxPid()
 	if maxPid > config.Sensor.ProcessInfoCacheSize {
-		cache.cache = newMapTaskCache()
+		cache.cache = newMapTaskCache(maxPid)
 	} else {
 		cache.cache = newArrayTaskCache(maxPid)
 	}
@@ -324,142 +421,33 @@ func makeExecveFetchArgs(reg string) string {
 	return strings.Join(parts, " ")
 }
 
-// lookupLeader finds the task info for the thread group leader of the given pid
-func (pc *ProcessInfoCache) lookupLeader(pid int) (task, bool) {
-	return pc.cache.LookupLeader(pid)
+// LookupTask finds the task information for the given PID.
+func (pc *ProcessInfoCache) LookupTask(pid int) (*Task, bool) {
+	return pc.cache.LookupTask(pid)
 }
 
-// ProcessID returns the unique ID for the thread group of the process
-// indicated by the given PID. This process ID is identical whether it
-// is derived inside or outside a container.
-func (pc *ProcessInfoCache) ProcessID(pid int) (string, bool) {
-	leader, ok := pc.lookupLeader(pid)
-	if ok {
-		return proc.DeriveUniqueID(leader.pid, leader.ppid), true
+// LookupTaskAndLeader finds the task information for both a given PID and the
+// thread group leader.
+func (pc *ProcessInfoCache) LookupTaskAndLeader(pid int) (*Task, *Task, bool) {
+	return pc.cache.LookupTaskAndLeader(pid)
+}
+
+// LookupTaskContainerInfo returns the container info for a task, possibly
+// consulting the sensor's container cache and updating the task cached
+// information.
+func (pc *ProcessInfoCache) LookupTaskContainerInfo(t *Task) *ContainerInfo {
+	if i := t.ContainerInfo; i != nil {
+		return t.ContainerInfo
 	}
 
-	return "", false
-}
-
-// ProcessContainerID returns the container ID that the process
-// indicated by the given host PID.
-func (pc *ProcessInfoCache) ProcessContainerID(pid int) (string, bool) {
-	t, ok := pc.cache.LookupLeader(pid)
-	if ok && len(t.containerID) > 0 {
-		return t.containerID, true
-	}
-	return "", false
-}
-
-// ProcessContainerInfo returns the container info for a process
-func (pc *ProcessInfoCache) ProcessContainerInfo(pid int) (*ContainerInfo, bool) {
-	t, ok := pc.cache.LookupLeader(pid)
-	if ok {
-		if t.containerInfo != nil {
-			return t.containerInfo, true
-		}
-		if len(t.containerID) > 0 {
-			cc := pc.sensor.containerCache
-			info := cc.lookupContainer(t.containerID, true)
-			if info != nil {
-				pc.cache.SetTaskContainerInfo(t.pid, info)
-				return info, true
-			}
+	if ID := t.ContainerID; len(ID) > 0 {
+		if i := pc.sensor.containerCache.lookupContainer(ID, true); i != nil {
+			t.ContainerInfo = i
+			return i
 		}
 	}
 
-	return nil, false
-}
-
-// ProcessCommandLine returns the command-line for a process. The command-line
-// is constructed from argv passed to execve(), but is limited to a fixed number
-// of elements of argv; therefore, it may not be complete.
-func (pc *ProcessInfoCache) ProcessCommandLine(pid int) ([]string, bool) {
-	var t task
-	ok := pc.cache.LookupTask(pid, &t)
-	return t.commandLine, ok
-}
-
-// ProcessCredentials returns the uid and gid for a process.
-func (pc *ProcessInfoCache) ProcessCredentials(pid int, c *Cred) bool {
-	var t task
-	ok := pc.cache.LookupTask(pid, &t)
-	*c = t.creds
-	return ok && t.creds.Initialized
-}
-
-//
-// task represents a schedulable task. All Linux tasks are uniquely
-// identified at a given time by their PID, but those PIDs may be
-// reused after hitting the maximum PID value.
-//
-type task struct {
-	// All Linux schedulable tasks are identified by a PID. This includes
-	// both processes and threads.
-	pid int
-
-	// Thread groups all have a leader, identified by its PID. The
-	// thread group leader has tgid == pid.
-	tgid int
-
-	// This ppid is of the originating parent process vs. current
-	// parent in case the parent terminates and the child is
-	// reparented (usually to init).
-	ppid int
-
-	// Flags passed to clone(2) when this process was created.
-	cloneFlags uint64
-
-	// This is the kernel's comm field, which is initialized to a
-	// the first 15 characters of the basename of the executable
-	// being run. It is also set via pthread_setname_np(3) and
-	// prctl(2) PR_SET_NAME. It is always NULL-terminated and no
-	// longer than 16 bytes (including NULL byte).
-	command string
-
-	// This is the command-line used when the process was exec'd via
-	// execve(). It is composed of the first 6 elements of argv. It may
-	// not be complete if argv contained more than 6 elements.
-	commandLine []string
-
-	// Process credentials (uid, gid). This is kept up-to-date by
-	// recording changes observed via a probe on commit_creds().
-	creds Cred
-
-	// Unique ID for the container instance
-	containerID   string
-	containerInfo *ContainerInfo
-}
-
-// Cred contains process credential information
-type Cred struct {
-	// Initialized is true when this struct has been initialized. This
-	// helps differentiate from processes running as root (all cred fields
-	// are legitimately set to 0).
-	Initialized bool
-
-	// UID is the real UID
-	UID uint32
-	// GID is the real GID
-	GID uint32
-
-	// EUID is the effective UID
-	EUID uint32
-
-	// EGID is the effective GID
-	EGID uint32
-
-	// SUID is the saved UID
-	SUID uint32
-
-	// SGID is the saved GID
-	SGID uint32
-
-	// FSUID is the UID for filesystem operations
-	FSUID uint32
-
-	// FSGID is the GID for filesystem operations
-	FSGID uint32
+	return nil
 }
 
 //
@@ -472,48 +460,39 @@ func (pc *ProcessInfoCache) decodeNewTask(
 	parentPid := int(data["common_pid"].(int32))
 	childPid := int(data["pid"].(int32))
 	cloneFlags := data["clone_flags"].(uint64)
+	childComm := commToString(data["comm"].([]interface{}))
 
-	// This is not ideal
-	comm := data["comm"].([]interface{})
-	comm2 := make([]byte, len(comm))
-	for i, c := range comm {
-		b := c.(int8)
-		if b == 0 {
-			break
-		}
+	var (
+		commandLine   []string
+		containerID   string
+		containerInfo *ContainerInfo
+	)
 
-		comm2[i] = byte(b)
+	parentTask, ok := pc.LookupTask(parentPid)
+	if ok {
+		commandLine = parentTask.CommandLine
+		containerID = parentTask.ContainerID
+		containerInfo = parentTask.ContainerInfo
 	}
-	command := string(comm2)
 
-	var tgid int
+	childTask := Task{
+		PID:           childPid,
+		PPID:          parentPid,
+		Command:       childComm,
+		CommandLine:   commandLine,
+		ContainerID:   containerID,
+		ContainerInfo: containerInfo,
+	}
 
 	const cloneThread = 0x10000 // CLONE_THREAD from the kernel
-	if (cloneFlags & cloneThread) != 0 {
-		tgid = parentPid
+	if cloneFlags&cloneThread != 0 {
+		childTask.TGID = parentPid
 	} else {
 		// This is a new thread group leader, tgid is the new pid
-		tgid = childPid
+		childTask.TGID = childPid
 	}
 
-	// Inherit container information from parent
-	var containerID string
-	containerInfo, _ := pc.ProcessContainerInfo(parentPid)
-	if containerInfo != nil {
-		containerID = containerInfo.ID
-	}
-
-	t := task{
-		pid:           childPid,
-		ppid:          parentPid,
-		tgid:          tgid,
-		cloneFlags:    cloneFlags,
-		command:       command,
-		containerID:   containerID,
-		containerInfo: containerInfo,
-	}
-
-	pc.cache.InsertTask(t.pid, t)
+	pc.cache.InsertTask(childPid, &childTask)
 
 	return nil, nil
 }
@@ -531,19 +510,22 @@ func (pc *ProcessInfoCache) decodeCommitCreds(
 		glog.Fatal("Received commit_creds with zero usage")
 	}
 
-	c := Cred{
-		Initialized: true,
-		UID:         data["uid"].(uint32),
-		GID:         data["gid"].(uint32),
-		EUID:        data["euid"].(uint32),
-		EGID:        data["egid"].(uint32),
-		SUID:        data["suid"].(uint32),
-		SGID:        data["sgid"].(uint32),
-		FSUID:       data["fsuid"].(uint32),
-		FSGID:       data["fsgid"].(uint32),
+	changes := map[string]interface{}{
+		"Creds": &Cred{
+			UID:   data["uid"].(uint32),
+			GID:   data["gid"].(uint32),
+			EUID:  data["euid"].(uint32),
+			EGID:  data["egid"].(uint32),
+			SUID:  data["suid"].(uint32),
+			SGID:  data["sgid"].(uint32),
+			FSUID: data["fsuid"].(uint32),
+			FSGID: data["fsgid"].(uint32),
+		},
 	}
 
-	pc.cache.SetTaskCredentials(pid, c)
+	if t, ok := pc.LookupTask(pid); ok {
+		t.Update(changes)
+	}
 
 	return nil, nil
 }
@@ -560,24 +542,29 @@ func (pc *ProcessInfoCache) decodeRuncTaskRename(
 
 	glog.V(10).Infof("decodeRuncTaskRename: pid = %d", pid)
 
-	var t task
-	pc.cache.LookupTask(pid, &t)
+	t, ok := pc.LookupTask(pid)
+	if !ok {
+		return nil, nil
+	}
 
-	if len(t.containerID) == 0 {
+	if len(t.ContainerID) == 0 {
 		containerID, err := procFS.ContainerID(pid)
 		glog.V(10).Infof("containerID(%d) = %s", pid, containerID)
 		if err == nil && len(containerID) > 0 {
-			pc.cache.SetTaskContainerID(pid, containerID)
+			changes := map[string]interface{}{
+				"ContainerID": containerID,
+			}
+			t.Update(changes)
 		}
-	} else {
-		var parent task
-		pc.cache.LookupTask(t.ppid, &parent)
-
-		if len(parent.containerID) == 0 {
-			containerID, err := procFS.ContainerID(parent.pid)
+	} else if parent, parentok := pc.LookupTask(t.PPID); parentok {
+		if len(parent.ContainerID) == 0 {
+			containerID, err := procFS.ContainerID(parent.PID)
 			glog.V(10).Infof("containerID(%d) = %s", pid, containerID)
 			if err == nil && len(containerID) > 0 {
-				pc.cache.SetTaskContainerID(parent.pid, containerID)
+				changes := map[string]interface{}{
+					"ContainerID": containerID,
+				}
+				parent.Update(changes)
 			}
 
 		}
@@ -592,6 +579,7 @@ func (pc *ProcessInfoCache) decodeExecve(
 	sample *perf.SampleRecord,
 	data perf.TraceEventSampleData,
 ) (interface{}, error) {
+	pid := int(data["common_pid"].(int32))
 	commandLine := make([]string, 0, execveArgCount)
 	for i := 0; i < execveArgCount; i++ {
 		s := data[fmt.Sprintf("argv%d", i)].(string)
@@ -601,8 +589,23 @@ func (pc *ProcessInfoCache) decodeExecve(
 		commandLine = append(commandLine, s)
 	}
 
-	pid := int(data["common_pid"].(int32))
-	pc.cache.SetTaskCommandLine(pid, commandLine)
+	changes := map[string]interface{}{
+		"CommandLine": commandLine,
+	}
+	if t, ok := pc.LookupTask(pid); ok {
+		t.Update(changes)
+	}
 
 	return nil, nil
+}
+
+func commToString(comm []interface{}) string {
+	s := make([]byte, len(comm))
+	for i, c := range comm {
+		s[i] = byte(c.(int8))
+		if s[i] == 0 {
+			return string(s[:i])
+		}
+	}
+	return string(s)
 }


### PR DESCRIPTION
This PR updates the process cache API to be more friendly to multiple lookups of data. The old API required a lookup for each piece of information. Using `arrayTaskCache` this isn't a big deal, but when `mapTaskCache` must be used, the performance penalty becomes significant. Updates to cache entries are handled in a similar fashion to the container cache, reducing the number of methods that must be implemented for the `taskCache` interface.