### PR TITLE
Add a public API to the container cache and expose it all

### DIFF
--- a/pkg/sensor/process_info.go
+++ b/pkg/sensor/process_info.go
@@ -349,10 +349,10 @@ type ProcessInfoCache struct {
 
 type scannerDeferredAction func()
 
-// newProcessInfoCache creates a new process information cache object. An
+// NewProcessInfoCache creates a new process information cache object. An
 // existing sensor object is required in order for the process info cache to
 // able to install its probes to monitor the system to maintain the cache.
-func newProcessInfoCache(sensor *Sensor) ProcessInfoCache {
+func NewProcessInfoCache(sensor *Sensor) ProcessInfoCache {
 	once.Do(func() {
 		procFS = sys.HostProcFS()
 		if procFS == nil {
@@ -584,7 +584,7 @@ func (pc *ProcessInfoCache) LookupTaskContainerInfo(t *Task) *ContainerInfo {
 	}
 
 	if ID := t.ContainerID; len(ID) > 0 {
-		if i := pc.sensor.containerCache.lookupContainer(ID, true); i != nil {
+		if i := pc.sensor.ContainerCache.LookupContainer(ID, true); i != nil {
 			t.ContainerInfo = i
 			return i
 		}

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -66,8 +66,8 @@ type Sensor struct {
 	monitor *perf.EventMonitor
 
 	// Per-sensor caches and monitors
-	containerCache *containerCache
 	ProcessCache   ProcessInfoCache
+	ContainerCache *ContainerCache
 	dockerMonitor  *dockerMonitor
 	ociMonitor     *ociMonitor
 
@@ -145,8 +145,8 @@ func (s *Sensor) Start() error {
 		return err
 	}
 
-	s.containerCache = newContainerCache(s)
-	s.ProcessCache = newProcessInfoCache(s)
+	s.ContainerCache = NewContainerCache(s)
+	s.ProcessCache = NewProcessInfoCache(s)
 
 	if len(config.Sensor.DockerContainerDir) > 0 {
 		s.dockerMonitor = newDockerMonitor(s,


### PR DESCRIPTION
Also update the container monitors to follow the same pattern for deferred actions as in the process monitor. I don't know what I was thinking initially with the container monitors (I wasn't) ...

Changes here are mainly for parity between the process cache and the container cache.

