### PR TITLE
Temporarily disable the OCI monitor

### DIFF
--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -152,9 +152,12 @@ func (s *Sensor) Start() error {
 		s.dockerMonitor = newDockerMonitor(s,
 			config.Sensor.DockerContainerDir)
 	}
+	/* Temporarily disable the OCI monitor until a better means of
+	   supporting it is found.
 	if len(config.Sensor.OciContainerDir) > 0 {
 		s.ociMonitor = newOciMonitor(s, config.Sensor.OciContainerDir)
 	}
+	*/
 
 	// Make sure that all events registered with the sensor's event monitor
 	// are active


### PR DESCRIPTION
Temporarily disable the OCI monitor until a better way can be found to implement it. The kprobe "ima_file_free" is not reliablely available on all kernels. Removal of the monitor has minimal impact at this time.

