### PR TITLE
Improve handling of sample timestamps in EventMonitor

### DIFF
--- a/pkg/sys/perf/ringbuffer.go
+++ b/pkg/sys/perf/ringbuffer.go
@@ -80,10 +80,6 @@ func (rb *ringBuffer) unmap() error {
 	return unix.Munmap(rb.memory)
 }
 
-func (rb *ringBuffer) timeRunning() uint64 {
-	return atomic.LoadUint64(&rb.metadata.TimeRunning)
-}
-
 // Read calls the given function on each available record in the ringbuffer
 func (rb *ringBuffer) read(f func([]byte)) {
 	var dataHead, dataTail uint64
@@ -115,4 +111,10 @@ func (rb *ringBuffer) read(f func([]byte)) {
 		// Update dataHead in case it has been advanced in the interim
 		dataHead = atomic.LoadUint64(&rb.metadata.DataHead)
 	}
+}
+
+// Flush discards all data from the ringbuffer
+func (rb *ringBuffer) flush() {
+	dataHead := atomic.LoadUint64(&rb.metadata.DataHead)
+	atomic.StoreUint64(&rb.metadata.DataTail, dataHead)
 }


### PR DESCRIPTION
This PR contains three primary changes:

1. Change the way timestamp offsets are computed. Timestamp offsets are used to help improve ordering of events across CPUs.
2. Use the system-wide monotonic clock for all events if it is supported by the running kernel (not available prior to Linux 4.1)
3. Merge samples from multiple CPUs as they're dispatched rather than sorting. Since samples from a given ring buffer are already in order, building a monolithic list from each CPU and then sorting it is a terrible waste of CPU time. A merge is much more efficient.