### PR TITLE
ensure we exceed the process's RLIMIT_NOFILE in the inotify fd leak test

### DIFF
--- a/pkg/sys/inotify/inotify_test.go
+++ b/pkg/sys/inotify/inotify_test.go
@@ -161,7 +161,8 @@ func TestStressInotifyInstances(t *testing.T) {
 	for i := 0; i < int(limit.Max)+100; i++ {
 		in, err := NewInstance()
 		if err != nil {
-			t.Error(err)
+			t.Errorf("soft fd limit is %v, hard fd limit is %v, got error: %v",
+				limit.Cur, limit.Max, err.Error())
 			break
 		}
 		in.Close()


### PR DESCRIPTION
I was starting to debug the inotify test failure and spotted a (somewhat low) hard-coded value in the file descriptor leak test. 
Many of the systems I work on have much higher limits, so I changed it to ensure it exceeds the process's RLIMIT_NOFILE.
