### PR TITLE
Add support for running the sensor on CentOS 6

### DIFF
--- a/pkg/sensor/container.go
+++ b/pkg/sensor/container.go
@@ -404,6 +404,7 @@ func (info *ContainerInfo) Update(
 
 func registerContainerEvents(
 	sensor *Sensor,
+	groupID int32,
 	eventMap subscriptionMap,
 	events []*api.ContainerEventFilter,
 ) {

--- a/pkg/sensor/file.go
+++ b/pkg/sensor/file.go
@@ -85,7 +85,12 @@ func rewriteFileEventFilter(fef *api.FileEventFilter) {
 	}
 }
 
-func registerFileEvents(sensor *Sensor, eventMap subscriptionMap, events []*api.FileEventFilter) {
+func registerFileEvents(
+	sensor *Sensor,
+	groupID int32,
+	eventMap subscriptionMap,
+	events []*api.FileEventFilter,
+) {
 	var filterString string
 
 	wildcard := false
@@ -137,6 +142,7 @@ func registerFileEvents(sensor *Sensor, eventMap subscriptionMap, events []*api.
 	eventID, err := sensor.monitor.RegisterKprobe(
 		fsDoSysOpenKprobeAddress, false,
 		fsDoSysOpenKprobeFetchargs, f.decodeDoSysOpen,
+		perf.WithEventGroup(groupID),
 		perf.WithFilter(filterString))
 	if err != nil {
 		glog.Warning("Couldn't register kprobe %s: %s",

--- a/pkg/sensor/kprobe.go
+++ b/pkg/sensor/kprobe.go
@@ -132,7 +132,12 @@ func (f *kprobeFilter) fetchargs() string {
 	return strings.Join(args, " ")
 }
 
-func registerKernelEvents(sensor *Sensor, eventMap subscriptionMap, events []*api.KernelFunctionCallFilter) {
+func registerKernelEvents(
+	sensor *Sensor,
+	groupID int32,
+	eventMap subscriptionMap,
+	events []*api.KernelFunctionCallFilter,
+) {
 	for _, kef := range events {
 		f := newKprobeFilter(kef)
 		if f == nil {
@@ -144,6 +149,7 @@ func registerKernelEvents(sensor *Sensor, eventMap subscriptionMap, events []*ap
 		eventID, err := sensor.monitor.RegisterKprobe(
 			f.symbol, f.onReturn, f.fetchargs(),
 			f.decodeKprobe,
+			perf.WithEventGroup(groupID),
 			perf.WithFilter(f.filter))
 		if err != nil {
 			var loc string

--- a/pkg/sensor/process_info_test.go
+++ b/pkg/sensor/process_info_test.go
@@ -36,10 +36,10 @@ const arrayTaskCacheSize = 32768
 const mapTaskCacheSize = 32768
 
 var values = []Task{
-	{1, 2, "foo", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil},
-	{1, 2, "bar", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil},
-	{1, 2, "baz", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil},
-	{1, 2, "qux", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil},
+	{1, 2, "foo", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil, 0},
+	{1, 2, "bar", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil, 0},
+	{1, 2, "baz", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil, 0},
+	{1, 2, "qux", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil, 0},
 }
 
 func TestCaches(t *testing.T) {

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -170,7 +170,7 @@ func (s *Sensor) Start() error {
 func (s *Sensor) Stop() {
 	if s.monitor != nil {
 		glog.V(2).Info("Stopping sensor-global EventMonitor")
-		s.monitor.Close(true)
+		s.monitor.Close()
 		s.monitor = nil
 		glog.V(2).Info("Sensor-global EventMonitor stopped successfully")
 	}

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -453,12 +454,18 @@ func (s *Sensor) createEventMonitor() error {
 func (s *Sensor) createPerfEventStream(sub *api.Subscription) (*stream.Stream, error) {
 	eventMap := newSubscriptionMap()
 
-	registerContainerEvents(s, eventMap, sub.EventFilter.ContainerEvents)
-	registerFileEvents(s, eventMap, sub.EventFilter.FileEvents)
-	registerKernelEvents(s, eventMap, sub.EventFilter.KernelEvents)
-	registerNetworkEvents(s, eventMap, sub.EventFilter.NetworkEvents)
-	registerProcessEvents(s, eventMap, sub.EventFilter.ProcessEvents)
-	registerSyscallEvents(s, eventMap, sub.EventFilter.SyscallEvents)
+	groupName := fmt.Sprintf("Subscription %p", sub)
+	groupID, err := s.monitor.RegisterEventGroup(groupName)
+	if err != nil {
+		return nil, err
+	}
+
+	registerContainerEvents(s, groupID, eventMap, sub.EventFilter.ContainerEvents)
+	registerFileEvents(s, groupID, eventMap, sub.EventFilter.FileEvents)
+	registerKernelEvents(s, groupID, eventMap, sub.EventFilter.KernelEvents)
+	registerNetworkEvents(s, groupID, eventMap, sub.EventFilter.NetworkEvents)
+	registerProcessEvents(s, groupID, eventMap, sub.EventFilter.ProcessEvents)
+	registerSyscallEvents(s, groupID, eventMap, sub.EventFilter.SyscallEvents)
 
 	if len(eventMap) == 0 {
 		return nil, nil
@@ -482,12 +489,15 @@ func (s *Sensor) createPerfEventStream(sub *api.Subscription) (*stream.Stream, e
 				glog.V(2).Infof("Subscription %d control channel closed",
 					subscriptionID)
 
+				s.monitor.UnregisterEventGroup(groupID)
 				s.eventMap.unsubscribe(subscriptionID,
 					func(eventID uint64) {
-						t, ok := s.monitor.RegisteredEventType(eventID)
-						if ok && t != perf.EventTypeExternal {
-							s.monitor.UnregisterEvent(eventID)
-						}
+						/*
+							t, ok := s.monitor.RegisteredEventType(eventID)
+							if ok && t != perf.EventTypeExternal {
+								s.monitor.UnregisterEvent(eventID)
+							}
+						*/
 					})
 				return
 			}

--- a/pkg/sys/kernel.go
+++ b/pkg/sys/kernel.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Capsule8, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"syscall"
+)
+
+// KernelVersion returns the version of the currently running kernel in major,
+// minor, patchlevel form.
+func KernelVersion() (int, int, int) {
+	var buf syscall.Utsname
+	err := syscall.Uname(&buf)
+	if err != nil {
+		return 0, 0, 0
+	}
+
+	var (
+		b    int
+		bits [3]int
+	)
+	for i := 0; i < len(buf.Release) && b < len(bits); i++ {
+		switch buf.Release[i] {
+		case '.':
+			b++
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			bits[b] = bits[b]*10 + int(buf.Release[i]) - '0'
+		default:
+			b = len(bits)
+		}
+	}
+
+	return bits[0], bits[1], bits[2]
+}

--- a/pkg/sys/perf/decoder.go
+++ b/pkg/sys/perf/decoder.go
@@ -282,10 +282,6 @@ func (m *traceEventDecoderMap) DecodeSample(sample *SampleRecord) (TraceEventSam
 		return nil, nil, err
 	}
 
-	if pid, ok := data["common_pid"].(int32); ok && pid == m.pid {
-		return nil, nil, nil
-	}
-
 	decodedSample, err := decoder.decoderfn(sample, data)
 	return data, decodedSample, err
 }

--- a/pkg/sys/perf/monitor.go
+++ b/pkg/sys/perf/monitor.go
@@ -920,9 +920,9 @@ func (monitor *EventMonitor) RegisteredEventType(
 // Close gracefully cleans up an EventMonitor instance. If the EventMonitor
 // is still running when Close is called, it will first be stopped. After
 // Close completes, the EventMonitor instance cannot be reused.
-func (monitor *EventMonitor) Close(wait bool) error {
+func (monitor *EventMonitor) Close() error {
 	// if the monitor is running, stop it and wait for it to stop
-	monitor.Stop(wait)
+	monitor.Stop(true)
 
 	// This lock isn't strictly necessary -- by the time .Close() is
 	// called, it would be a programming error for multiple go routines
@@ -2084,7 +2084,7 @@ func NewEventMonitor(options ...EventMonitorOption) (*EventMonitor, error) {
 			path := filepath.Join(opts.perfEventDir, cgroup)
 			fd, err = unix.Open(path, unix.O_RDONLY, 0)
 			if err != nil {
-				monitor.Close(true)
+				monitor.Close()
 				return nil, err
 			}
 			monitor.cgroups = append(monitor.cgroups, fd)
@@ -2108,7 +2108,7 @@ func NewEventMonitor(options ...EventMonitorOption) (*EventMonitor, error) {
 
 	_, err = monitor.RegisterEventGroup("default")
 	if err != nil {
-		monitor.Close(true)
+		monitor.Close()
 		return nil, err
 	}
 

--- a/pkg/sys/perf/ringbuffer.go
+++ b/pkg/sys/perf/ringbuffer.go
@@ -112,9 +112,3 @@ func (rb *ringBuffer) read(f func([]byte)) {
 		dataHead = atomic.LoadUint64(&rb.metadata.DataHead)
 	}
 }
-
-// Flush discards all data from the ringbuffer
-func (rb *ringBuffer) flush() {
-	dataHead := atomic.LoadUint64(&rb.metadata.DataHead)
-	atomic.StoreUint64(&rb.metadata.DataTail, dataHead)
-}

--- a/pkg/sys/perf/ringbuffer.go
+++ b/pkg/sys/perf/ringbuffer.go
@@ -77,7 +77,13 @@ func newRingBuffer(fd int, pageCount int) (*ringBuffer, error) {
 }
 
 func (rb *ringBuffer) unmap() error {
-	return unix.Munmap(rb.memory)
+	if rb.memory != nil {
+		if err := unix.Munmap(rb.memory); err != nil {
+			return err
+		}
+		rb.memory = nil
+	}
+	return nil
 }
 
 // Read calls the given function on each available record in the ringbuffer


### PR DESCRIPTION
CentOS 6.6 (based on RedHat Enterprise Linux) is the earliest version of CentOS that the sensor can reasonably support. This version uses a Linux kernel version of 2.6.32-504, which has much of the perf framework back ported to it from Linux kernel version 3.10. While the code has been back ported, it is not without problems. Namely, wakeups involving groups that have had events removed from them cause kernel panics. Therefore, work must be done in the sensor to avoid this problem.

The changes here are primarily in support of using perf groups in such a way to avoid kernel panics. Instead of using one group for all events, there is now one group that is used for sensor-internal probes and each subscription gets its own group. When a subscription is canceled, the group that belonged to it is removed, along with all of the perf events that were attached to it. The sensor-internal group never removes events once they are added.

Additional changes to support CentOS kernels is to work around missing tracepoints that are available in newer kernels, upon which the sensor depends. Specifically, the `task/task_newtask` tracepoint is normally used to learn about new tasks created by the kernel. Instead, task tracking is done using a combination of kprobes and other tracepoints when the `task/task_newtask` tracepoint is not available.

There is no support in CentOS 6 for containers. Therefore, Docker and other container engines are not supported. This does have the side-effect of making the sensor's functional tests non-functional on CentOS 6 since they depend on containers. Example telemetry code has been used for testing purposes during development.