### PR TITLE
Make the process cache better handle out-of-order events

### DIFF
--- a/examples/cache-side-channel/main.go
+++ b/examples/cache-side-channel/main.go
@@ -168,14 +168,12 @@ func alarm(s *sensor.Sensor, sr *perf.SampleRecord, counters eventCounters) {
 	fields = append(fields, fmt.Sprintf("tid=%v", sr.Tid))
 	fields = append(fields, fmt.Sprintf("cpu=%v", sr.CPU))
 
-	if task, ok := s.ProcessCache.LookupTask(int(sr.Pid)); ok {
-		containerInfo := s.ProcessCache.LookupTaskContainerInfo(task)
-		if containerInfo != nil {
-			fields = append(fields, fmt.Sprintf("container_name=%v", containerInfo.Name))
-			fields = append(fields, fmt.Sprintf("container_id=%v", containerInfo.ID))
-			fields = append(fields, fmt.Sprintf("container_image=%v", containerInfo.ImageName))
-			fields = append(fields, fmt.Sprintf("container_image_id=%v", containerInfo.ImageID))
-		}
+	task := s.ProcessCache.LookupTask(int(sr.Pid))
+	if ci := s.ProcessCache.LookupTaskContainerInfo(task); ci != nil {
+		fields = append(fields, fmt.Sprintf("container_name=%v", ci.Name))
+		fields = append(fields, fmt.Sprintf("container_id=%v", ci.ID))
+		fields = append(fields, fmt.Sprintf("container_image=%v", ci.ImageName))
+		fields = append(fields, fmt.Sprintf("container_image_id=%v", ci.ImageID))
 	}
 
 	message := strings.Join(fields, " ")

--- a/pkg/sensor/consts.go
+++ b/pkg/sensor/consts.go
@@ -1,0 +1,53 @@
+// Code generated automatically. DO NOT EDIT.
+// It isn't really, but the above line causes golint to not check this file.
+// This file contains Linux kernel constants that do not conform to Go's
+// usual naming conventions. It may at some point in the future become
+// automatically generated.
+
+// Copyright 2017 Capsule8, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sensor
+
+const (
+	_ uint = 0
+
+	/*
+	 * cloning flags:
+	 */
+	CSIGNAL              = 0x000000ff /* signal mask to be sent at exit */
+	CLONE_VM             = 0x00000100 /* set if VM shared between processes */
+	CLONE_FS             = 0x00000200 /* set if fs info shared between processes */
+	CLONE_FILES          = 0x00000400 /* set if open files shared between processes */
+	CLONE_SIGHAND        = 0x00000800 /* set if signal handlers and blocked signals shared */
+	CLONE_PTRACE         = 0x00002000 /* set if we want to let tracing continue on the child too */
+	CLONE_VFORK          = 0x00004000 /* set if the parent wants the child to wake it up on mm_release */
+	CLONE_PARENT         = 0x00008000 /* set if we want to have the same parent as the cloner */
+	CLONE_THREAD         = 0x00010000 /* Same thread group? */
+	CLONE_NEWNS          = 0x00020000 /* New mount namespace group */
+	CLONE_SYSVSEM        = 0x00040000 /* share system V SEM_UNDO semantics */
+	CLONE_SETTLS         = 0x00080000 /* create a new TLS for the child */
+	CLONE_PARENT_SETTID  = 0x00100000 /* set the TID in the parent */
+	CLONE_CHILD_CLEARTID = 0x00200000 /* clear the TID in the child */
+	CLONE_DETACHED       = 0x00400000 /* Unused, ignored */
+	CLONE_UNTRACED       = 0x00800000 /* set if the tracing process can't force CLONE_PTRACE on this clone */
+	CLONE_CHILD_SETTID   = 0x01000000 /* set the TID in the child */
+	CLONE_NEWCGROUP      = 0x02000000 /* New cgroup namespace */
+	CLONE_NEWUTS         = 0x04000000 /* New utsname namespace */
+	CLONE_NEWIPC         = 0x08000000 /* New ipc namespace */
+	CLONE_NEWUSER        = 0x10000000 /* New user namespace */
+	CLONE_NEWPID         = 0x20000000 /* New pid namespace */
+	CLONE_NEWNET         = 0x40000000 /* New network namespace */
+	CLONE_IO             = 0x80000000 /* Clone io context */
+)

--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -49,7 +49,7 @@ func (f *processFilter) decodeSchedProcessFork(sample *perf.SampleRecord, data p
 		},
 	}
 
-	if _, l, _ := f.sensor.ProcessCache.LookupTaskAndLeader(int(childPid)); l != nil {
+	if _, l := f.sensor.ProcessCache.LookupTaskAndLeader(int(childPid)); l != nil {
 		ev.GetProcess().ForkChildId = l.ProcessID()
 	}
 
@@ -63,8 +63,8 @@ func (f *processFilter) decodeSchedProcessExec(sample *perf.SampleRecord, data p
 	// Get the command-line from the process info cache. If it's not there
 	// for whatever reason, fallback to using procfs
 	var commandLine []string
-	_, l, _ := f.sensor.ProcessCache.LookupTaskAndLeader(int(hostPid))
-	if l == nil || l.CommandLine == nil || len(l.CommandLine) == 0 {
+	_, l := f.sensor.ProcessCache.LookupTaskAndLeader(int(hostPid))
+	if l.CommandLine == nil || len(l.CommandLine) == 0 {
 		commandLine = sys.HostProcFS().CommandLine(int(hostPid))
 	} else {
 		commandLine = l.CommandLine

--- a/pkg/sensor/process_info_test.go
+++ b/pkg/sensor/process_info_test.go
@@ -15,7 +15,6 @@
 package sensor
 
 import (
-	"math/rand"
 	"os"
 	"testing"
 )
@@ -26,8 +25,6 @@ Current benchmark results:
 
 BenchmarkArrayCache-8                   	500000000	         3.18 ns/op
 BenchmarkMapCache-8                     	10000000	       152 ns/op
-BenchmarkArrayCacheParallel-8           	2000000000	         1.56 ns/op
-BenchmarkMapCacheParallel-8             	 5000000	       252 ns/op
 BenchmarkStatCacheMiss-8                	  200000	     11180 ns/op
 BenchmarkStatCacheMissParallel-8        	  500000	      3460 ns/op
 BenchmarkContainerCacheMiss-8           	  100000	     14729 ns/op
@@ -39,222 +36,58 @@ const arrayTaskCacheSize = 32768
 const mapTaskCacheSize = 32768
 
 var values = []Task{
-	{1, 2, 3, "foo", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, ""},
-	{1, 2, 3, "bar", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, ""},
-	{1, 2, 3, "baz", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, ""},
-	{1, 2, 3, "qux", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, ""},
+	{1, 2, "foo", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil},
+	{1, 2, "bar", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil},
+	{1, 2, "baz", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil},
+	{1, 2, "qux", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil},
 }
 
 func TestCaches(t *testing.T) {
-
 	arrayCache := newArrayTaskCache(arrayTaskCacheSize)
 	mapCache := newMapTaskCache(mapTaskCacheSize)
 
-	for i := 0; i < arrayTaskCacheSize-1; i++ {
-		arrayCache.InsertTask(i+1, &values[i%4])
-		mapCache.InsertTask(i+1, &values[i%4])
+	var task *Task
+
+	for i := 0; i < arrayTaskCacheSize; i++ {
+		task = arrayCache.LookupTask(i + 1)
+		task.ContainerID = values[i%4].ContainerID
+	}
+	for i := 0; i < mapTaskCacheSize; i++ {
+		task = mapCache.LookupTask(i + 1)
+		task.ContainerID = values[i%4].ContainerID
 	}
 
 	for i := arrayTaskCacheSize - 2; i >= 0; i-- {
-		if tk, ok := arrayCache.LookupTask(i + 1); ok {
-			cid := tk.ContainerID
-			if cid != values[i%4].ContainerID {
-				t.Fatalf("Expected %s for pid %d, got %s",
-					values[i%4].ContainerID, i, cid)
-			}
-
-		}
-
-		if tk, ok := mapCache.LookupTask(i + 1); ok {
-			cid := tk.ContainerID
-			if cid != values[i%4].ContainerID {
-				t.Fatalf("Expected %s for pid %d, got %s",
-					values[i%4].ContainerID, i, cid)
-			}
-
-		}
-	}
-}
-
-func randomTgid(pidMap map[int]int) int {
-	var tgids []int
-
-	for p := range pidMap {
-		if pidMap[p] == p {
-			tgids = append(tgids, p)
+		task = arrayCache.LookupTask(i + 1)
+		cid := task.ContainerID
+		if cid != values[i%4].ContainerID {
+			t.Fatalf("Expected %s for pid %d, got %s",
+				values[i%4].ContainerID, i, cid)
 		}
 	}
 
-	return tgids[rand.Intn(len(tgids))]
-}
-
-func nextPid(pidMap map[int]int, maxPid int, lastPid *int) {
-	lp := *lastPid
-
-	for {
-		// Advance last pid
-		*lastPid = (*lastPid + 1) % maxPid
-		if *lastPid == 0 {
-			// pid 0 is illegal
-			*lastPid = 1
-		}
-
-		if *lastPid == lp {
-			if lp == 1 {
-				panic("Can't delete pid 1")
-			}
-
-			for p := range pidMap {
-				if pidMap[p] == *lastPid {
-					delete(pidMap, *lastPid)
-				}
-			}
-
-			return
-		}
-
-		_, found := pidMap[*lastPid]
-		if !found {
-			return
-		}
-	}
-}
-
-func TestCacheCycle(t *testing.T) {
-	maxPid := 128
-	cache := newArrayTaskCache(uint(maxPid))
-
-	// pidMap is a map of pids to tgid
-	pidMap := make(map[int]int)
-
-	// Create init process
-	lastPid := 1
-	pidMap[lastPid] = lastPid
-
-	initTask := &Task{
-		PID:  lastPid,
-		PPID: 0,
-		TGID: lastPid,
-	}
-	cache.InsertTask(lastPid, initTask)
-
-	for i := 0; i < 10000; i++ {
-		// Choose a random current process
-		pid := randomTgid(pidMap)
-
-		r := rand.Intn(100)
-		if r < 10 {
-			// Fork a new child process
-
-			// Choose a random unused pid
-			nextPid(pidMap, maxPid, &lastPid)
-
-			// Add to pidMap with tgid == self
-			pidMap[lastPid] = lastPid
-
-			newTask := &Task{
-				PID:  lastPid,
-				PPID: pid,
-				TGID: lastPid,
-			}
-			cache.InsertTask(lastPid, newTask)
-		} else if r < 20 {
-			// Terminate tgid
-			if pid != 1 {
-				// Delete tgid and all of its threads
-				for p := range pidMap {
-					if pidMap[p] == pid {
-						delete(pidMap, p)
-					}
-				}
-			}
-
-		} else if pid != 1 {
-			// Clone a new thread
-			nextPid(pidMap, maxPid, &lastPid)
-
-			// Add to pidMap with tgid == parent pid
-			pidMap[lastPid] = pid
-
-			newTask := &Task{
-				PID:  lastPid,
-				PPID: pid,
-				TGID: pid,
-			}
-			cache.InsertTask(lastPid, newTask)
-		}
-
-		// Make sure that we can traverse process ancestry for every
-		// pid. If this enters an infinite loop, then we somehow got a
-		// cycle.
-		for i := range pidMap {
-			cache.LookupTaskAndLeader(i)
+	for i := mapTaskCacheSize - 2; i >= 0; i-- {
+		task = mapCache.LookupTask(i + 1)
+		cid := task.ContainerID
+		if cid != values[i%4].ContainerID {
+			t.Fatalf("Expected %s for pid %d, got %s",
+				values[i%4].ContainerID, i, cid)
 		}
 	}
 }
 
 func BenchmarkArrayCache(b *testing.B) {
 	cache := newArrayTaskCache(arrayTaskCacheSize)
-
 	for i := 0; i < b.N; i++ {
-		cache.InsertTask((i%arrayTaskCacheSize)+1, &values[i%4])
-	}
-
-	for i := 0; i < b.N; i++ {
-		_, _ = cache.LookupTask((i % arrayTaskCacheSize) + 1)
+		_ = cache.LookupTask((i % arrayTaskCacheSize) + 1)
 	}
 }
 
 func BenchmarkMapCache(b *testing.B) {
 	cache := newMapTaskCache(mapTaskCacheSize)
-
 	for i := 0; i < b.N; i++ {
-		cache.InsertTask((i%arrayTaskCacheSize)+1, &values[i%4])
+		_ = cache.LookupTask((i % arrayTaskCacheSize) + 1)
 	}
-
-	for i := 0; i < b.N; i++ {
-		_, _ = cache.LookupTask((i % arrayTaskCacheSize) + 1)
-	}
-}
-
-func BenchmarkArrayCacheParallel(b *testing.B) {
-	cache := newArrayTaskCache(arrayTaskCacheSize)
-
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			cache.InsertTask((i%arrayTaskCacheSize)+1, &values[i%4])
-			i++
-		}
-	})
-
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			_, _ = cache.LookupTask((i % arrayTaskCacheSize) + 1)
-			i++
-		}
-	})
-}
-
-func BenchmarkMapCacheParallel(b *testing.B) {
-	cache := newMapTaskCache(mapTaskCacheSize)
-
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			cache.InsertTask((i%arrayTaskCacheSize)+1, &values[i%4])
-			i++
-		}
-	})
-
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			_, _ = cache.LookupTask((i % arrayTaskCacheSize) + 1)
-			i++
-		}
-	})
 }
 
 func BenchmarkStatCacheMiss(b *testing.B) {

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -322,8 +322,8 @@ func (s *Sensor) NewEventFromSample(
 	e.ProcessPid, _ = data["common_pid"].(int32)
 	e.Cpu = int32(sample.CPU)
 
-	pid := int(e.ProcessPid)
-	if task, leader, ok := s.ProcessCache.LookupTaskAndLeader(pid); ok {
+	if e.ProcessPid != 0 {
+		task, leader := s.ProcessCache.LookupTaskAndLeader(int(e.ProcessPid))
 		e.ProcessId = leader.ProcessID()
 		e.ProcessTgid = int32(task.TGID)
 
@@ -347,7 +347,6 @@ func (s *Sensor) NewEventFromSample(
 			e.ImageName = i.ImageName
 		}
 	}
-
 	return e
 }
 


### PR DESCRIPTION
Despite best efforts to process events in the order in which they occur, it is not always possible to do so. When more than one CPU is in use, there are inherent race conditions that prevent perfect ordering. Therefore, the task cache in the sensor must be resilient to receiving out-of-order events and make a best effort to provide as much information as is available when telemetry events are generated. 

With these changes, lookups of tasks from the cache will always succeed, with whatever information is available. As kernel events occur that provide more information resulting in altered cache information, the cache will be updated and future telemetry events will reflect the new information.

Sensor clients must expect that there are cases in which some telemetry events will occur that do not have all of the desired information because the kernel events providing that information have not been processed yet. There is little more that the sensor can do to alleviate that situation. Telemetry events emitted by the sensor have always been a "best effort" to provide as much useful information as possible, but all possible information has never been--nor will ever be--a guarantee.