### PR TITLE
Use monotonic clocks for computing timeouts

### DIFF
--- a/pkg/sys/time.go
+++ b/pkg/sys/time.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Capsule8, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// CurrentMonotonicRaw is a convenience function that returns that current
+// system raw monotonic clock as an integer.
+func CurrentMonotonicRaw() int64 {
+	var ts unix.Timespec
+	unix.ClockGettime(unix.CLOCK_MONOTONIC_RAW, &ts)
+	return ts.Nano()
+}


### PR DESCRIPTION
This helps to better define the meaning of timestamps in external events. Also made changes to adjust CPU clocks to a fixed monotonic base. It's still not ideal as nothing will ever be, but it helps manage consistency with timestamps throughout `EventMonitor`