### PR TITLE
Add link in README to api protocol docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ sample code in `examples/` updated with any changes to the API.
   * [Quickstart](#Quickstart)
   * [Architecture](docs/Architecture.md)
   * [System Requirements](docs/System-Requirements.md)
-  * [Definitions](docs/Definitions.md) 
+  * [API Protocol](docs/API.md)
+  * [Definitions](docs/Definitions.md)
   * [KProbes](docs/KProbes.md)
   * [FAQ](docs/FAQ.md)
 


### PR DESCRIPTION
This PR adds the docs/API.md link to the main README where we are now linking the rest of the docs repo