### PR TITLE
Remove the use of the streams package from the sensor

### DIFF
--- a/api/v0/subscription.pb.go
+++ b/api/v0/subscription.pb.go
@@ -89,12 +89,13 @@ type Subscription struct {
 	// the specified relative duration subtracted from the current
 	// time (recorder time). If the resulting time is in the past, then the
 	// subscription will search for historic events before streaming
-	// live ones.
+	// live ones. Sensors do not honor this field.
 	SinceDuration *google_protobuf1.Int64Value `protobuf:"bytes,10,opt,name=since_duration,json=sinceDuration" json:"since_duration,omitempty"`
 	// If not empty, then only return events that occurred before
 	// the specified relative duration added to `since_duration`.
 	// If `since_duration` is not supplied, return events from now and until
-	// the specified relative duration is hit.
+	// the specified relative duration is hit. Sensors do not honor this
+	// field.
 	ForDuration *google_protobuf1.Int64Value `protobuf:"bytes,11,opt,name=for_duration,json=forDuration" json:"for_duration,omitempty"`
 	// If not empty, apply the specified modifier to the subscription.
 	Modifier *Modifier `protobuf:"bytes,20,opt,name=modifier" json:"modifier,omitempty"`
@@ -691,7 +692,7 @@ func (m *Modifier) GetLimit() *LimitModifier {
 type ThrottleModifier struct {
 	// Required; the interval to use
 	Interval int64 `protobuf:"varint,1,opt,name=interval" json:"interval,omitempty"`
-	// Required; the intreval type (milliseconds, seconds, etc.)
+	// Required; the interval type (milliseconds, seconds, etc.)
 	IntervalType ThrottleModifier_IntervalType `protobuf:"varint,2,opt,name=interval_type,json=intervalType,enum=capsule8.api.v0.ThrottleModifier_IntervalType" json:"interval_type,omitempty"`
 }
 
@@ -716,7 +717,7 @@ func (m *ThrottleModifier) GetIntervalType() ThrottleModifier_IntervalType {
 
 // The LimitModifier cancels the subscription on each Sensor after the
 // specified number of events. The entire Subscription may return more
-// events that this depending on how many active Sensors there are.
+// events than this depending on how many active Sensors there are.
 type LimitModifier struct {
 	// Limit the number of events
 	Limit int64 `protobuf:"varint,1,opt,name=limit" json:"limit,omitempty"`

--- a/api/v0/subscription.proto
+++ b/api/v0/subscription.proto
@@ -38,13 +38,14 @@ message Subscription {
         // the specified relative duration subtracted from the current
         // time (recorder time). If the resulting time is in the past, then the
         // subscription will search for historic events before streaming
-        // live ones.
+        // live ones. Sensors do not honor this field.
         google.protobuf.Int64Value since_duration = 10;
 
         // If not empty, then only return events that occurred before
         // the specified relative duration added to `since_duration`.
         // If `since_duration` is not supplied, return events from now and until
-        // the specified relative duration is hit.
+        // the specified relative duration is hit. Sensors do not honor this
+        // field.
         google.protobuf.Int64Value for_duration = 11;
 
         // If not empty, apply the specified modifier to the subscription.
@@ -310,13 +311,13 @@ message ThrottleModifier {
                 HOUR = 3;
         }
 
-        // Required; the intreval type (milliseconds, seconds, etc.)
+        // Required; the interval type (milliseconds, seconds, etc.)
         IntervalType interval_type = 2;
 }
 
 // The LimitModifier cancels the subscription on each Sensor after the
 // specified number of events. The entire Subscription may return more
-// events that this depending on how many active Sensors there are.
+// events than this depending on how many active Sensors there are.
 message LimitModifier {
         // Limit the number of events
         int64 limit = 1;

--- a/docs/API.md
+++ b/docs/API.md
@@ -880,7 +880,7 @@ kernel function call.
 ### LimitModifier
 The LimitModifier cancels the subscription on each Sensor after the
 specified number of events. The entire Subscription may return more
-events that this depending on how many active Sensors there are.
+events than this depending on how many active Sensors there are.
 
 
 | Field | Type | Label | Description |
@@ -960,8 +960,8 @@ telemetry events.
 | ----- | ---- | ----- | ----------- |
 | event_filter | [EventFilter](#capsule8.api.v0.EventFilter) |  | Return events matching one or more of the specified event filters. If no event filters are specified, then no events will be returned. |
 | container_filter | [ContainerFilter](#capsule8.api.v0.ContainerFilter) |  | If not empty, then only return events from containers matched by one or more of the specified container filters. |
-| since_duration | [.google.protobuf.Int64Value](#capsule8.api.v0..google.protobuf.Int64Value) |  | If not empty, then only return events that occurred after the specified relative duration subtracted from the current time (recorder time). If the resulting time is in the past, then the subscription will search for historic events before streaming live ones. |
-| for_duration | [.google.protobuf.Int64Value](#capsule8.api.v0..google.protobuf.Int64Value) |  | If not empty, then only return events that occurred before the specified relative duration added to `since_duration`. If `since_duration` is not supplied, return events from now and until the specified relative duration is hit. |
+| since_duration | [.google.protobuf.Int64Value](#capsule8.api.v0..google.protobuf.Int64Value) |  | If not empty, then only return events that occurred after the specified relative duration subtracted from the current time (recorder time). If the resulting time is in the past, then the subscription will search for historic events before streaming live ones. Sensors do not honor this field. |
+| for_duration | [.google.protobuf.Int64Value](#capsule8.api.v0..google.protobuf.Int64Value) |  | If not empty, then only return events that occurred before the specified relative duration added to `since_duration`. If `since_duration` is not supplied, return events from now and until the specified relative duration is hit. Sensors do not honor this field. |
 | modifier | [Modifier](#capsule8.api.v0.Modifier) |  | If not empty, apply the specified modifier to the subscription. |
 
 
@@ -1005,7 +1005,7 @@ time interval specified.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | interval | [int64](#int64) |  | Required; the interval to use |
-| interval_type | [ThrottleModifier.IntervalType](#capsule8.api.v0.ThrottleModifier.IntervalType) |  | Required; the intreval type (milliseconds, seconds, etc.) |
+| interval_type | [ThrottleModifier.IntervalType](#capsule8.api.v0.ThrottleModifier.IntervalType) |  | Required; the interval type (milliseconds, seconds, etc.) |
 
 
 

--- a/pkg/sensor/container_test.go
+++ b/pkg/sensor/container_test.go
@@ -21,20 +21,23 @@ import (
 )
 
 func TestFilterContainerId(t *testing.T) {
-	cf := newContainerFilter(&api.ContainerFilter{
+	cf, err := newContainerFilter(&api.ContainerFilter{
 		Ids: []string{
 			"alice",
 			"bob",
 		},
 	})
+	if err != nil {
+		t.Error(err)
+	}
 
-	if match := cf.FilterFunc(&api.TelemetryEvent{
+	if match := cf.match(&api.TelemetryEvent{
 		ContainerId: "alice",
 	}); !match {
 		t.Error("No matching container ID found for alice")
 	}
 
-	if match := cf.FilterFunc(&api.TelemetryEvent{
+	if match := cf.match(&api.TelemetryEvent{
 		ContainerId: "bill",
 	}); match {
 		t.Error("Unexpected matching container ID found for bill")
@@ -42,14 +45,17 @@ func TestFilterContainerId(t *testing.T) {
 }
 
 func TestFilterContainerImageId(t *testing.T) {
-	cf := newContainerFilter(&api.ContainerFilter{
+	cf, err := newContainerFilter(&api.ContainerFilter{
 		ImageIds: []string{
 			"alice",
 			"bob",
 		},
 	})
+	if err != nil {
+		t.Error(err)
+	}
 
-	if match := cf.FilterFunc(&api.TelemetryEvent{
+	if match := cf.match(&api.TelemetryEvent{
 		ContainerId: "pass",
 		Event: &api.TelemetryEvent_Container{
 			Container: &api.ContainerEvent{
@@ -60,7 +66,7 @@ func TestFilterContainerImageId(t *testing.T) {
 		t.Error("No matching container image ID found for alice")
 	}
 
-	if match := cf.FilterFunc(&api.TelemetryEvent{
+	if match := cf.match(&api.TelemetryEvent{
 		ContainerId: "fail",
 		Event: &api.TelemetryEvent_Container{
 			Container: &api.ContainerEvent{
@@ -73,14 +79,17 @@ func TestFilterContainerImageId(t *testing.T) {
 }
 
 func TestFilterContainerImageNames(t *testing.T) {
-	cf := newContainerFilter(&api.ContainerFilter{
+	cf, err := newContainerFilter(&api.ContainerFilter{
 		ImageNames: []string{
 			"alice",
 			"bob",
 		},
 	})
+	if err != nil {
+		t.Error(err)
+	}
 
-	if match := cf.FilterFunc(&api.TelemetryEvent{
+	if match := cf.match(&api.TelemetryEvent{
 		ContainerId: "pass",
 		Event: &api.TelemetryEvent_Container{
 			Container: &api.ContainerEvent{
@@ -91,7 +100,7 @@ func TestFilterContainerImageNames(t *testing.T) {
 		t.Error("No matching image name found for alice")
 	}
 
-	if match := cf.FilterFunc(&api.TelemetryEvent{
+	if match := cf.match(&api.TelemetryEvent{
 		ContainerId: "fail",
 		Event: &api.TelemetryEvent_Container{
 			Container: &api.ContainerEvent{
@@ -104,14 +113,17 @@ func TestFilterContainerImageNames(t *testing.T) {
 }
 
 func TestFilterContainerNames(t *testing.T) {
-	cf := newContainerFilter(&api.ContainerFilter{
+	cf, err := newContainerFilter(&api.ContainerFilter{
 		Names: []string{
 			"alice",
 			"bob",
 		},
 	})
+	if err != nil {
+		t.Error(err)
+	}
 
-	if match := cf.FilterFunc(&api.TelemetryEvent{
+	if match := cf.match(&api.TelemetryEvent{
 		ContainerId: "pass",
 		Event: &api.TelemetryEvent_Container{
 			Container: &api.ContainerEvent{
@@ -122,7 +134,7 @@ func TestFilterContainerNames(t *testing.T) {
 		t.Error("No matching container name found for alice")
 	}
 
-	if match := cf.FilterFunc(&api.TelemetryEvent{
+	if match := cf.match(&api.TelemetryEvent{
 		ContainerId: "fail",
 		Event: &api.TelemetryEvent_Container{
 			Container: &api.ContainerEvent{

--- a/test/functional/monitor/main.go
+++ b/test/functional/monitor/main.go
@@ -53,8 +53,8 @@ func decodeDoExit(sample *perf.SampleRecord, data perf.TraceEventSampleData) (in
 	return nil, nil
 }
 
-func onSample(eventID uint64, sample perf.EventMonitorSample) {
-	nSamples++
+func onSamples(samples []perf.EventMonitorSample) {
+	nSamples += uint(len(samples))
 	// Do nothing
 }
 
@@ -96,7 +96,7 @@ func main() {
 	monitor.EnableAll()
 
 	glog.Info("Running monitor")
-	monitor.Run(onSample)
+	monitor.Run(onSamples)
 	glog.Info("Monitor stopped")
 
 	glog.Infof("Received %d samples, %d events",


### PR DESCRIPTION
There are a number of changes here, but all are primarily in support of removing the use of the streams package from the sensor. The rationale for removing the use of the streams package from the sensor is that it is not Go-like and that it adds significant overhead in using numerous levels of unnecessary channels.

The chargen and ticker events are now piped through `EventMonitor` to remove the dependency on `stream.Joiner`.

The `EventMonitor` has been modified so that it dispatches samples to the callback specified in the call to `EventMonitor.Run` in batch. Since samples are already in batches as they're removed from ringbuffers, this makes sense. It also allows the dispatch callback to better optimize its dispatch because it knows there are bunches of samples coming. Given the nature of the `EventMonitor` and its need to maintain sample ordering, dispatch does not benefit from parallelization, so a one-at-a-time approach is a bigger negative.

The implementation of subscription container filters and modifiers is now handled at the telemetry service level rather than in the sensor. This is done to improve performance in the sensor itself. The existing implementation was not doing proper synchronization, which could lead to obvious problems. Leaving these implementations at the sensor level means adding atomic increments and mutexes for each and every event. It also adds more bookkeeping overhead.

I wrestled with the aforementioned change, but ultimately decided to make it for performance reasons, reduced complexity, and because it allows for a clean break between the Sensor object and the API. The Sensor object is responsible for monitoring the system and generating telemetry events. The telemetry service is responsible for inspecting those events and dispatching them to clients via the gRPC stream.

Internally in the Sensor object, the use of synchronization primitives and Go's currently terrible channel implementation is avoided on the premise that the Sensor itself needs to function as quickly as it can and since it does not lend itself to parallelization, there is no benefit to using channels. 

Other issues uncovered while doing this work:
1. If a client stream blocks, all telemetry to all subscriptions would block. This has been changed so that if a client stream is blocked for some reason, other client subscriptions will continue to receive telemetry. Events destined for the blocked client will be dropped.
2. Throttling behavior via `stream.Stream` is problematic. It delays reading from the data channel for the interval, ultimately resulting in the channel filling up blocking. Among other problems, this exacerbates the problem described above. With the fix for the above, this is less of an issue, but it raises the question of whether events received during the interval should be queued or should they be dropped? The original behavior means the client will fall behind and will always continue to fall further and further behind as time goes on. In my opinion, the better behavior is for the client to always be current, but indicate it is only interested in periodic updates. The throttling modifier is of dubious value to my mind anyway, but since the Sensor is designed to be lossy, discarding events occurring during the throttle interval seems to me to make more sense.
3. Use of the dual channel streams is decidedly un-Go-like. The Sensor object's `NewSubscription` API now favors the use of Go's context pattern. While they're both effectively the same, the latter is "The Go Way".
4. I had original intended to replace container filters with expressions using the expression package, but this will not work because the expression package would need support for sets and an `IN` operator. Container filters therefore remain a special-purpose filter.
