### PR TITLE
Fix benchmark crash on startup introduced in #157

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ bin/*
 examples/telemetry/telemetry
 examples/kprobe/kprobe
 examples/kinesis-firehose-forwarder/kinesis-firehose-forwarder
+test/benchmark/benchmark
 
 # Ignore log files
 *.log


### PR DESCRIPTION
There's no reason to instantiate the service manager and telemetry service in `init()`. Doing it in `main()` is a better place. The specific problem that's being fixed here though is that `defer testSensor.Stop()` would run after `init()` finished, rendering the sensor stopped upon entry to `main()`.