### PR TITLE
Filter docker/oci config from events based on ContainerView in subscriptions

### DIFF
--- a/pkg/sensor/container.go
+++ b/pkg/sensor/container.go
@@ -443,6 +443,7 @@ func registerContainerEvents(
 				eventID = sensor.ContainerCache.ContainerUpdatedEventID
 			}
 			subscriptions[t] = subscr.addEventSink(eventID)
+			subscriptions[t].containerView = cef.View
 		}
 		filters[t] = expression.LogicalOr(filters[t], cef.FilterExpression)
 	}

--- a/pkg/sensor/container.go
+++ b/pkg/sensor/container.go
@@ -32,7 +32,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"google.golang.org/genproto/googleapis/rpc/code"
-	google_rpc "google.golang.org/genproto/googleapis/rpc/status"
 )
 
 var containerEventTypes = expression.FieldTypeMap{
@@ -413,24 +412,20 @@ func (info *ContainerInfo) Update(
 
 func registerContainerEvents(
 	sensor *Sensor,
-	groupID int32,
-	eventMap subscriptionMap,
+	subscr *subscription,
 	events []*api.ContainerEventFilter,
-) []*google_rpc.Status {
+) {
 	var (
-		status        []*google_rpc.Status
 		filters       [6]*api.Expression
-		subscriptions [6]*subscription
+		subscriptions [6]*eventSink
 	)
 
 	for _, cef := range events {
 		t := cef.Type
 		if t < 1 || t > 5 {
-			status = append(status,
-				&google_rpc.Status{
-					Code:    int32(code.Code_INVALID_ARGUMENT),
-					Message: fmt.Sprintf("ContainerEventType %d is invalid", t),
-				})
+			subscr.logStatus(
+				code.Code_INVALID_ARGUMENT,
+				fmt.Sprintf("ContainerEventType %d is invalid", t))
 			continue
 		}
 		if subscriptions[t] == nil {
@@ -447,7 +442,7 @@ func registerContainerEvents(
 			case api.ContainerEventType_CONTAINER_EVENT_TYPE_UPDATED:
 				eventID = sensor.ContainerCache.ContainerUpdatedEventID
 			}
-			subscriptions[t] = eventMap.subscribe(eventID)
+			subscriptions[t] = subscr.addEventSink(eventID)
 		}
 		filters[t] = expression.LogicalOr(filters[t], cef.FilterExpression)
 	}
@@ -461,31 +456,25 @@ func registerContainerEvents(
 		expr, err := expression.NewExpression(filters[i])
 		if err != nil {
 			// Bad filter. Remove subscription
-			status = append(status,
-				&google_rpc.Status{
-					Code:    int32(code.Code_INVALID_ARGUMENT),
-					Message: fmt.Sprintf("Invalid container filter expression: %v", err),
-				})
-			eventMap.unsubscribe(s.eventID)
+			subscr.logStatus(
+				code.Code_INVALID_ARGUMENT,
+				fmt.Sprintf("Invalid container filter expression: %v", err))
+			subscr.removeEventSink(s)
 			continue
 		}
 
 		err = expr.Validate(containerEventTypes)
 		if err != nil {
 			// Bad filter. Remove subscription
-			status = append(status,
-				&google_rpc.Status{
-					Code:    int32(code.Code_INVALID_ARGUMENT),
-					Message: fmt.Sprintf("Invalid container filter expression: %v", err),
-				})
-			eventMap.unsubscribe(s.eventID)
+			subscr.logStatus(
+				code.Code_INVALID_ARGUMENT,
+				fmt.Sprintf("Invalid container filter expression: %v", err))
+			subscr.removeEventSink(s)
 			continue
 		}
 
 		s.filter = expr
 	}
-
-	return status
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/sensor/subscription.go
+++ b/pkg/sensor/subscription.go
@@ -38,10 +38,11 @@ type eventSinkDispatchFn func(event *api.TelemetryEvent)
 type eventSinkUnregisterFn func(es *eventSink)
 
 type eventSink struct {
-	subscription *subscription
-	eventID      uint64
-	unregister   eventSinkUnregisterFn
-	filter       *expression.Expression
+	subscription  *subscription
+	eventID       uint64
+	unregister    eventSinkUnregisterFn
+	filter        *expression.Expression
+	containerView api.ContainerEventView
 }
 
 func (s *subscription) addEventSink(eventID uint64) *eventSink {

--- a/pkg/sys/perf/monitor.go
+++ b/pkg/sys/perf/monitor.go
@@ -2276,6 +2276,10 @@ func (monitor *EventMonitor) RegisterEventGroup(name string) (int32, error) {
 	monitor.registerNewEventGroup(group)
 	monitor.lock.Unlock()
 
+	if len(group.name) == 0 {
+		group.name = fmt.Sprintf("EventGroup %d", group.groupID)
+	}
+
 	return group.groupID, nil
 }
 


### PR DESCRIPTION
This PR also contains a big clean up of the internal representation of a subscription within the `Sensor` object, as well as moving the container filtering from a subscription back into the `Sensor` object, because I ultimately believe that's where it should reside.

When docker/oci configuration information is stripped from events before dispatch if not requested by a subscription, a deep copy of the event is made first (if more than one event sink is present for the same `eventID`) so that other subscriptions are not affected.