### PR TITLE
Stabilize ProcessId by using boot id, pid, and start time

### DIFF
--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -53,8 +53,8 @@ func (f *processFilter) decodeSchedProcessFork(sample *perf.SampleRecord, data p
 		},
 	}
 
-	if _, l := f.sensor.ProcessCache.LookupTaskAndLeader(int(childPid)); l != nil {
-		ev.GetProcess().ForkChildId = l.ProcessID()
+	if t := f.sensor.ProcessCache.LookupTask(int(childPid)); t != nil {
+		ev.GetProcess().ForkChildId = t.ProcessID
 	}
 
 	return ev, nil

--- a/pkg/sensor/process_info_test.go
+++ b/pkg/sensor/process_info_test.go
@@ -36,10 +36,10 @@ const arrayTaskCacheSize = 32768
 const mapTaskCacheSize = 32768
 
 var values = []Task{
-	{1, 2, "foo", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil, 0},
-	{1, 2, "bar", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil, 0},
-	{1, 2, "baz", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil, 0},
-	{1, 2, "qux", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, "", nil, 0},
+	{1, 2, "foo", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", nil, 0},
+	{1, 2, "bar", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", nil, 0},
+	{1, 2, "baz", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", nil, 0},
+	{1, 2, "qux", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", nil, 0},
 }
 
 func TestCaches(t *testing.T) {
@@ -94,7 +94,7 @@ func BenchmarkStatCacheMiss(b *testing.B) {
 	pid := os.Getpid()
 
 	for i := 0; i < b.N; i++ {
-		_ = procFS.Stat(pid)
+		_ = procFS.Stat(pid, pid)
 	}
 }
 
@@ -103,7 +103,7 @@ func BenchmarkStatCacheMissParallel(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = procFS.Stat(pid)
+			_ = procFS.Stat(pid, pid)
 		}
 	})
 }

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -314,7 +314,7 @@ func (s *Sensor) NewEventFromSample(
 
 	e.ProcessPid = pid
 	if pid != 0 {
-		e.ProcessId = leader.ProcessID()
+		e.ProcessId = task.ProcessID
 		e.ProcessTgid = int32(task.TGID)
 
 		if c := task.Creds; c != nil {


### PR DESCRIPTION
If the process is so short-lived that a start time cannot be acquired from the proc fs, use the timestamp on the sample that caused the sensor to learn of the process. Since it's short-lived, it won't be found on a successive scan of the proc fs on a sensor restart anyway, so the actual timestamp used doesn't really matter as long as the value chosen cannot be reused again later.

