### PR TITLE
Fix the offsets for decoding credentials from the kernel

### DIFF
--- a/pkg/sensor/process_info.go
+++ b/pkg/sensor/process_info.go
@@ -47,10 +47,10 @@ const taskReuseThreshold = int64(10 * time.Millisecond)
 const (
 	commitCredsAddress = "commit_creds"
 	commitCredsArgs    = "usage=+0(%di):u64 " +
-		"uid=+8(%di):u32 gid=+12(%di):u32 " +
-		"suid=+16(%di):u32 sgid=+20(%di):u32 " +
-		"euid=+24(%di):u32 egid=+28(%di):u32 " +
-		"fsuid=+32(%di):u32 fsgid=+36(%di):u32"
+		"uid=+4(%di):u32 gid=+8(%di):u32 " +
+		"suid=+12(%di):u32 sgid=+16(%di):u32 " +
+		"euid=+20(%di):u32 egid=+24(%di):u32 " +
+		"fsuid=+28(%di):u32 fsgid=+32(%di):u32"
 
 	execveArgCount = 6
 


### PR DESCRIPTION
The offsets used in the kprobe to get credentials from the kernel's `comment_creds` function were off by 4. The assumption was made that `atomic_t usage` was 8 bytes, but is in fact only 4. The uid/gid information that follows is not aligned to an 8-byte boundary, because their integer types are only 4 bytes wide.