### PR TITLE
Update changelog for 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.8.1-alpha (Apr 11, 2018)
+
+BACKWARDS INCOMPATIBILITIES:
+
+  None
+
+FEATURES:
+
+  None
+
+IMPROVEMENTS:
+
+  None
+
+BUG FIXES:
+
+  * Fix the offsets for decoding credentials from the kernel ([#186](https://github.com/capsule8/capsule8/pull/186))
+
 ## 0.8.0-alpha (Mar 7, 2018)
 
 BACKWARDS INCOMPATIBILITIES:


### PR DESCRIPTION
This PR updates the changelog for the 0.8 release branch to include a patch for the uid gid offset bug.

This release will also need to be added to the master branch documentation