### PR TITLE
Child tasks should inherit credentials from parent tasks

### DIFF
--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -872,6 +872,7 @@ func (pc *ProcessInfoCache) handleSysClone(
 ) {
 	changes := map[string]interface{}{
 		"Command": childComm,
+		"Creds":   parentTask.Creds,
 	}
 
 	if (cloneFlags & CLONE_THREAD) != 0 {


### PR DESCRIPTION
When a process forks (clones), its children should inherit its credentials, which include uid, gid, euid, egid, etc.