### PR TITLE
Handle out of order fork events on kernels older than 3.9

### DIFF
--- a/pkg/sensor/process_test.go
+++ b/pkg/sensor/process_test.go
@@ -36,10 +36,10 @@ const arrayTaskCacheSize = 32768
 const mapTaskCacheSize = 32768
 
 var values = []Task{
-	{1, 2, "foo", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", "", nil, 0},
-	{1, 2, "bar", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", "", nil, 0},
-	{1, 2, "baz", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", "", nil, 0},
-	{1, 2, "qux", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", "", nil, 0},
+	{1, 2, "foo", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", "", nil, nil},
+	{1, 2, "bar", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", "", nil, nil},
+	{1, 2, "baz", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", "", nil, nil},
+	{1, 2, "qux", nil, nil, "6e250051f33e0988aa6e549daa6c36de5ddf296bced4f31cf1b8249556f27ed2", nil, 0, 0, "", "", nil, nil},
 }
 
 func TestCaches(t *testing.T) {


### PR DESCRIPTION
Kernels older than 3.9 do not have the `task/task_newtask` tracepoint, which gives the sensor everything it needs in one event to handle task cloning. For kernels lacking this tracepoint, a kprobe and a different tracepoint must be used, but one depends on the data from the other. Since events can sometimes come out of order when they occur on different CPUs, the sensor must be able to handle these two events coming out of order. The intent was there prior to this revision, but the work to handle it properly was never completed. This revision completes it.

