### PR TITLE
Simplify golint go get command in circle ci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            mkdir -p $GOPATH/src/golang.org/x \
-                && git clone https://github.com/golang/lint.git $GOPATH/src/golang.org/x/lint \
-                && go get -u golang.org/x/lint/golint
+            go get -u github.com/golang/lint/golint
 
       - run:
           name: Check source code syntax, formatting, style, and lint


### PR DESCRIPTION
This PR reverts #190 which was a hotfix for an issue with the golint package. That command is working again and the work around is now causing circle ci to fail