### PR TITLE
Add the 0.8.1 release to the master branch changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,28 @@ BUG FIXES:
   * Manually clone go lint in circle ci ([#190](https://github.com/capsule8/capsule8/pull/190))
   * Fix the offsets for decoding credentials from the kernel ([#185](https://github.com/capsule8/capsule8/pull/185))
 
+## 0.8.1-alpha (Apr 11, 2018)
+
+BACKWARDS INCOMPATIBILITIES:
+
+  None
+
+FEATURES:
+
+  None
+
+IMPROVEMENTS:
+
+  None
+
+BUG FIXES:
+
+  * Fix the offsets for decoding credentials from the kernel ([#186](https://github.com/capsule8/capsule8/pull/186))
+
+Notes:
+
+  This release is on the `release-0.8` branch
+
 ## 0.10.1-alpha (Apr 9, 2018)
 
 BACKWARDS INCOMPATIBILITIES:


### PR DESCRIPTION
#193 Did not include all changes to all release branches.
This PR adds the documentation of 0.8.1-alpha to the master branch changelog.
There is a note in the documentation for that release that it is specifically not in the master branch history

I think having all releases represented in master is useful. This PR tries to clarify that not all releases are on the master branch