### PR TITLE
Remove duplicate __cgroup_procs_write kprobe

### DIFF
--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -528,14 +528,6 @@ func NewProcessInfoCache(sensor *Sensor) ProcessInfoCache {
 		glog.Fatalf("Couldn't register event %s: %s", eventName, err)
 	}
 
-	eventName = cgroupProcsWriteAddress
-	_, err = sensor.Monitor.RegisterKprobe(eventName, false,
-		cgroupProcsWriteArgs, cache.decodeCgroupProcsWrite,
-		perf.WithEventEnabled())
-	if err != nil {
-		glog.Fatalf("Couldn't register event %s: %s", eventName, err)
-	}
-
 	// Attach kprobe on commit_creds to capture task privileges
 	_, err = sensor.Monitor.RegisterKprobe(commitCredsAddress, false,
 		commitCredsArgs, cache.decodeCommitCreds,


### PR DESCRIPTION
This duplicate kprobe for `__cgroup_procs_write` slipped in during testing. The one that is registered later is the right one.

