### PR TITLE
Update cgroup monitoring to work with all supported kernels

### DIFF
--- a/pkg/sensor/docker_monitor.go
+++ b/pkg/sensor/docker_monitor.go
@@ -106,7 +106,7 @@ func newDockerMonitor(sensor *Sensor, containerDir string) *dockerMonitor {
 	// right away. Otherwise there'll be race conditions as we scan the
 	// filesystem for existing containers
 
-	_, err = sensor.Monitor.RegisterKprobe(dockerRenameKprobeSymbol, false,
+	_, err = sensor.RegisterKprobe(dockerRenameKprobeSymbol, false,
 		dockerRenameKprobeFetchargs, dm.decodeRename,
 		perf.WithFilter(dockerRenameKprobeFilter),
 		perf.WithEventEnabled())
@@ -115,7 +115,7 @@ func newDockerMonitor(sensor *Sensor, containerDir string) *dockerMonitor {
 			dockerRenameKprobeSymbol, err)
 	}
 
-	_, err = sensor.Monitor.RegisterKprobe(dockerUnlinkKprobeSymbol, false,
+	_, err = sensor.RegisterKprobe(dockerUnlinkKprobeSymbol, false,
 		dockerUnlinkKprobeFetchargs, dm.decodeUnlink,
 		perf.WithFilter(dockerUnlinkKprobeFilter),
 		perf.WithEventEnabled())

--- a/pkg/sensor/file.go
+++ b/pkg/sensor/file.go
@@ -149,7 +149,7 @@ func registerFileEvents(
 		sensor: sensor,
 	}
 
-	eventID, err := sensor.Monitor.RegisterKprobe(
+	eventID, err := sensor.RegisterKprobe(
 		fsDoSysOpenKprobeAddress, false,
 		fsDoSysOpenKprobeFetchargs, f.decodeDoSysOpen,
 		perf.WithEventGroup(subscr.eventGroupID),

--- a/pkg/sensor/kprobe.go
+++ b/pkg/sensor/kprobe.go
@@ -151,7 +151,7 @@ func registerKernelEvents(
 		}
 
 		f.sensor = sensor
-		eventID, err := sensor.Monitor.RegisterKprobe(
+		eventID, err := sensor.RegisterKprobe(
 			f.symbol, f.onReturn, f.fetchargs(),
 			f.decodeKprobe,
 			perf.WithEventGroup(subscr.eventGroupID),

--- a/pkg/sensor/network.go
+++ b/pkg/sensor/network.go
@@ -312,7 +312,7 @@ func fullFilterString(filters map[string]int) (string, bool) {
 }
 
 func registerEvent(
-	monitor *perf.EventMonitor,
+	sensor *Sensor,
 	subscr *subscription,
 	name string,
 	fn perf.TraceEventDecoderFn,
@@ -323,7 +323,7 @@ func registerEvent(
 		return
 	}
 
-	eventID, err := monitor.RegisterTracepoint(name, fn,
+	eventID, err := sensor.Monitor.RegisterTracepoint(name, fn,
 		perf.WithEventGroup(subscr.eventGroupID),
 		perf.WithFilter(f))
 	if err != nil {
@@ -337,7 +337,7 @@ func registerEvent(
 }
 
 func registerKprobe(
-	monitor *perf.EventMonitor,
+	sensor *Sensor,
 	subscr *subscription,
 	symbol string,
 	fetchargs string,
@@ -349,7 +349,7 @@ func registerKprobe(
 		return
 	}
 
-	eventID, err := monitor.RegisterKprobe(symbol, false, fetchargs, fn,
+	eventID, err := sensor.RegisterKprobe(symbol, false, fetchargs, fn,
 		perf.WithEventGroup(subscr.eventGroupID),
 		perf.WithFilter(f))
 	if err != nil {
@@ -376,33 +376,33 @@ func registerNetworkEvents(
 		sensor: sensor,
 	}
 
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_enter_accept", f.decodeSysEnterAccept, nfs.acceptAttemptFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_accept", f.decodeSysExitAccept, nfs.acceptResultFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_enter_accept4", f.decodeSysEnterAccept, nfs.acceptAttemptFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_accept4", f.decodeSysExitAccept, nfs.acceptResultFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_enter_accept", f.decodeSysEnterAccept, nfs.acceptAttemptFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_accept", f.decodeSysExitAccept, nfs.acceptResultFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_enter_accept4", f.decodeSysEnterAccept, nfs.acceptAttemptFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_accept4", f.decodeSysExitAccept, nfs.acceptResultFilters)
 
-	registerKprobe(sensor.Monitor, subscr, networkKprobeBindSymbol, networkKprobeBindFetchargs, f.decodeSysBind, nfs.bindAttemptFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_bind", f.decodeSysExitBind, nfs.bindResultFilters)
+	registerKprobe(sensor, subscr, networkKprobeBindSymbol, networkKprobeBindFetchargs, f.decodeSysBind, nfs.bindAttemptFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_bind", f.decodeSysExitBind, nfs.bindResultFilters)
 
-	registerKprobe(sensor.Monitor, subscr, networkKprobeConnectSymbol, networkKprobeConnectFetchargs, f.decodeSysConnect, nfs.connectAttemptFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_connect", f.decodeSysExitConnect, nfs.connectResultFilters)
+	registerKprobe(sensor, subscr, networkKprobeConnectSymbol, networkKprobeConnectFetchargs, f.decodeSysConnect, nfs.connectAttemptFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_connect", f.decodeSysExitConnect, nfs.connectResultFilters)
 
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_enter_listen", f.decodeSysEnterListen, nfs.listenAttemptFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_listen", f.decodeSysExitListen, nfs.listenResultFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_enter_listen", f.decodeSysEnterListen, nfs.listenAttemptFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_listen", f.decodeSysExitListen, nfs.listenResultFilters)
 
 	// There are two additional system calls added in Linux 3.0 that are of
 	// interest, but there's no way to get all of the data without eBPF
 	// support, so don't bother with them for now.
 
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_enter_recvfrom", f.decodeSysEnterRecvfrom, nfs.recvfromAttemptFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_enter_recvmsg", f.decodeSysEnterRecvfrom, nfs.recvfromAttemptFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_enter_recvfrom", f.decodeSysEnterRecvfrom, nfs.recvfromAttemptFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_enter_recvmsg", f.decodeSysEnterRecvfrom, nfs.recvfromAttemptFilters)
 
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_recvfrom", f.decodeSysExitRecvfrom, nfs.recvfromResultFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_recvmsg", f.decodeSysExitRecvfrom, nfs.recvfromResultFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_recvfrom", f.decodeSysExitRecvfrom, nfs.recvfromResultFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_recvmsg", f.decodeSysExitRecvfrom, nfs.recvfromResultFilters)
 
-	registerKprobe(sensor.Monitor, subscr, networkKprobeSendmsgSymbol, networkKprobeSendmsgFetchargs, f.decodeSysSendto, nfs.sendtoAttemptFilters)
-	registerKprobe(sensor.Monitor, subscr, networkKprobeSendtoSymbol, networkKprobeSendtoFetchargs, f.decodeSysSendto, nfs.sendtoAttemptFilters)
+	registerKprobe(sensor, subscr, networkKprobeSendmsgSymbol, networkKprobeSendmsgFetchargs, f.decodeSysSendto, nfs.sendtoAttemptFilters)
+	registerKprobe(sensor, subscr, networkKprobeSendtoSymbol, networkKprobeSendtoFetchargs, f.decodeSysSendto, nfs.sendtoAttemptFilters)
 
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_sendmsg", f.decodeSysExitSendto, nfs.sendtoResultFilters)
-	registerEvent(sensor.Monitor, subscr, "syscalls/sys_exit_sendto", f.decodeSysExitSendto, nfs.sendtoResultFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_sendmsg", f.decodeSysExitSendto, nfs.sendtoResultFilters)
+	registerEvent(sensor, subscr, "syscalls/sys_exit_sendto", f.decodeSysExitSendto, nfs.sendtoResultFilters)
 }

--- a/pkg/sensor/oci_monitor.go
+++ b/pkg/sensor/oci_monitor.go
@@ -97,7 +97,7 @@ func newOciMonitor(sensor *Sensor, containerDir string) *ociMonitor {
 	// right away. Otherwise there'll be race conditions as we scan
 	// the filesystem for existing containers.
 
-	_, err = sensor.Monitor.RegisterKprobe(ociSysOpenKprobeSymbol, false,
+	_, err = sensor.RegisterKprobe(ociSysOpenKprobeSymbol, false,
 		ociSysOpenKprobeFetchargs, om.decodeSysOpen,
 		perf.WithFilter(ociSysOpenKprobeFilter),
 		perf.WithEventEnabled())
@@ -105,7 +105,7 @@ func newOciMonitor(sensor *Sensor, containerDir string) *ociMonitor {
 		glog.Fatalf("Could not register OCI monitor %s kprobe: %s",
 			ociSysOpenKprobeSymbol, err)
 	}
-	_, err = sensor.Monitor.RegisterKprobe(ociImaFileFreeKprobeSymbol, false,
+	_, err = sensor.RegisterKprobe(ociImaFileFreeKprobeSymbol, false,
 		ociImaFileFreeKprobeFetchargs, om.decodeImaFileFree,
 		perf.WithFilter(ociImaFileFreeKprobeFilter),
 		perf.WithEventEnabled())
@@ -114,7 +114,7 @@ func newOciMonitor(sensor *Sensor, containerDir string) *ociMonitor {
 			ociImaFileFreeKprobeSymbol, err)
 	}
 
-	_, err = sensor.Monitor.RegisterKprobe(ociUnlinkKprobeSymbol, false,
+	_, err = sensor.RegisterKprobe(ociUnlinkKprobeSymbol, false,
 		ociUnlinkKprobeFetchargs, om.decodeUnlink,
 		perf.WithFilter(ociUnlinkKprobeFilter),
 		perf.WithEventEnabled())

--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -493,12 +493,12 @@ func NewProcessInfoCache(sensor *Sensor) *ProcessInfoCache {
 		perf.WithEventEnabled())
 	if err != nil {
 		eventName = doForkAddress
-		_, err = sensor.Monitor.RegisterKprobe(eventName, false,
+		_, err = sensor.RegisterKprobe(eventName, false,
 			doForkFetchargs, cache.decodeDoFork,
 			perf.WithEventEnabled())
 		if err != nil {
 			eventName = "_" + eventName
-			_, err = sensor.Monitor.RegisterKprobe(eventName, false,
+			_, err = sensor.RegisterKprobe(eventName, false,
 				doForkFetchargs, cache.decodeDoFork,
 				perf.WithEventEnabled())
 			if err != nil {
@@ -521,7 +521,7 @@ func NewProcessInfoCache(sensor *Sensor) *ProcessInfoCache {
 	}
 
 	eventName = doExitAddress
-	_, err = sensor.Monitor.RegisterKprobe(eventName, false,
+	_, err = sensor.RegisterKprobe(eventName, false,
 		doExitArgs, cache.decodeDoExit,
 		perf.WithEventEnabled())
 	if err != nil {
@@ -529,17 +529,17 @@ func NewProcessInfoCache(sensor *Sensor) *ProcessInfoCache {
 	}
 
 	// Attach kprobe on commit_creds to capture task privileges
-	_, err = sensor.Monitor.RegisterKprobe(commitCredsAddress, false,
+	_, err = sensor.RegisterKprobe(commitCredsAddress, false,
 		commitCredsArgs, cache.decodeCommitCreds,
 		perf.WithEventEnabled())
 
 	// Attach kretprobe on set_fs_pwd to track working directories
-	_, err = sensor.Monitor.RegisterKprobe(doSetFsPwd, true,
+	_, err = sensor.RegisterKprobe(doSetFsPwd, true,
 		"", cache.decodeDoSetFsPwd,
 		perf.WithEventEnabled())
 
 	eventName = cgroupProcsWriteAddress
-	_, err = sensor.Monitor.RegisterKprobe(eventName, false,
+	_, err = sensor.RegisterKprobe(eventName, false,
 		cgroupProcsWriteArgs, cache.decodeCgroupProcsWrite,
 		perf.WithEventEnabled())
 	if err != nil {
@@ -566,13 +566,13 @@ func NewProcessInfoCache(sensor *Sensor) *ProcessInfoCache {
 	// if that succeeds, it's the only one we need. Otherwise, we need a
 	// bunch of others to try to hit everything. We may end up getting
 	// duplicate events, which is ok.
-	_, err = sensor.Monitor.RegisterKprobe(
+	_, err = sensor.RegisterKprobe(
 		doExecveatCommonAddress, false,
 		doExecveatCommonArgs+makeExecveFetchArgs("dx"),
 		cache.decodeExecve,
 		perf.WithEventEnabled())
 	if err != nil {
-		_, err = sensor.Monitor.RegisterKprobe(
+		_, err = sensor.RegisterKprobe(
 			sysExecveAddress, false,
 			sysExecveArgs+makeExecveFetchArgs("si"),
 			cache.decodeExecve,
@@ -581,19 +581,19 @@ func NewProcessInfoCache(sensor *Sensor) *ProcessInfoCache {
 			glog.Fatalf("Couldn't register event %s: %s",
 				sysExecveAddress, err)
 		}
-		_, _ = sensor.Monitor.RegisterKprobe(
+		_, _ = sensor.RegisterKprobe(
 			doExecveAddress, false,
 			doExecveArgs+makeExecveFetchArgs("si"),
 			cache.decodeExecve,
 			perf.WithEventEnabled())
 
-		_, err = sensor.Monitor.RegisterKprobe(
+		_, err = sensor.RegisterKprobe(
 			sysExecveatAddress, false,
 			sysExecveatArgs+makeExecveFetchArgs("dx"),
 			cache.decodeExecve,
 			perf.WithEventEnabled())
 		if err == nil {
-			_, _ = sensor.Monitor.RegisterKprobe(
+			_, _ = sensor.RegisterKprobe(
 				doExecveatAddress, false,
 				makeExecveFetchArgs("dx"), cache.decodeExecve,
 				perf.WithEventEnabled())

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -15,6 +15,7 @@
 package sensor
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/rand"
@@ -22,6 +23,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,6 +72,12 @@ type Sensor struct {
 	// A sensor-global event monitor that is used for events to aid in
 	// caching process information
 	Monitor *perf.EventMonitor
+
+	// A lookup table of available kernel symbols. The key is the symbol
+	// name as would be used with RegisterKprobe. The value is the actual
+	// symbol that should be used, which is normally the same, but can
+	// sometimes differ due to compiler name mangling.
+	kallsyms map[string]string
 
 	// Per-sensor caches and monitors
 	ProcessCache   *ProcessInfoCache
@@ -165,6 +173,7 @@ func (s *Sensor) Start() error {
 		s.Stop()
 		return err
 	}
+	s.loadKernelSymbols()
 
 	s.ContainerCache = NewContainerCache(s)
 	s.ProcessCache = NewProcessInfoCache(s)
@@ -391,6 +400,34 @@ func (s *Sensor) buildMonitorGroups() ([]string, []int, error) {
 	return cgroupList, pidList, nil
 }
 
+func (s *Sensor) loadKernelSymbols() {
+	filename := filepath.Join(sys.ProcFS().MountPoint, "kallsyms")
+	f, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	s.kallsyms = make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		// Only record symbols in text segments
+		if fields[1] != "t" && fields[1] != "T" {
+			continue
+		}
+		parts := strings.Split(fields[2], ".")
+		if len(parts) < 1 {
+			continue
+		}
+		s.kallsyms[parts[0]] = fields[2]
+	}
+}
+
 func (s *Sensor) createEventMonitor() error {
 	eventMonitorOptions := []perf.EventMonitorOption{}
 
@@ -459,6 +496,41 @@ func (s *Sensor) createEventMonitor() error {
 	}()
 
 	return nil
+}
+
+// IsKernelSymbolAvailable checks to see if the specified kprobe symbol is
+// available for use in the running kernel.
+func (s *Sensor) IsKernelSymbolAvailable(symbol string) bool {
+	// If the kallsyms mapping is nil, the table could not be
+	// loaded for some reason; assume anything is available
+	if s.kallsyms == nil {
+		return true
+	}
+
+	_, ok := s.kallsyms[symbol]
+	return ok
+}
+
+// RegisterKprobe registers a kprobe with the sensor's EventMonitor instance,
+// but before doing so, ensures that the kernel symbol is available.
+func (s *Sensor) RegisterKprobe(
+	address string,
+	onReturn bool,
+	output string,
+	fn perf.TraceEventDecoderFn,
+	options ...perf.RegisterEventOption,
+) (uint64, error) {
+	if s.kallsyms != nil {
+		if actual, ok := s.kallsyms[address]; ok {
+			if actual != address {
+				glog.V(2).Infof("Using %q for kprobe symbol %q", actual, address)
+				address = actual
+			}
+		} else {
+			return 0, fmt.Errorf("Kernel symbol not found: %s", address)
+		}
+	}
+	return s.Monitor.RegisterKprobe(address, onReturn, output, fn, options...)
 }
 
 // NewSubscription creates a new telemetry subscription from the given

--- a/pkg/sensor/syscall.go
+++ b/pkg/sensor/syscall.go
@@ -300,7 +300,7 @@ func registerSyscallEvents(
 		// because the old probe will also set in the newer kernels,
 		// but it won't fire.
 		kprobeSymbol := syscallNewEnterKprobeAddress
-		eventID, err = sensor.Monitor.RegisterKprobe(
+		eventID, err = sensor.RegisterKprobe(
 			kprobeSymbol, false,
 			syscallEnterKprobeFetchargs,
 			f.decodeSyscallTraceEnter,
@@ -308,7 +308,7 @@ func registerSyscallEvents(
 			perf.WithFilter(filter))
 		if err != nil {
 			kprobeSymbol = syscallOldEnterKprobeAddress
-			eventID, err = sensor.Monitor.RegisterKprobe(
+			eventID, err = sensor.RegisterKprobe(
 				kprobeSymbol, false,
 				syscallEnterKprobeFetchargs,
 				f.decodeSyscallTraceEnter,


### PR DESCRIPTION
CentOS 6.6+, CentOS 7.x, and stock kernel versions 3.10 through 4.16 have been evaluated and should all work with these changes. I haven't tested every kernel version, but I've spot checked many, and all seems well. Kernel source has been evaluated for all supported versions, however.

The change included here to filter kprobe registrations through `/proc/kallsyms` is important. Doing this rewrites symbols in some cases from the programmatic name in kernel source to the compiler/linker generated name. It's unusual, but they do differ sometimes, and in fact one of the symbols that is hooked for cgroup monitoring is affected on some kernel versions. This change also has the side-effect of being able to probe the kernel for symbols without generating kernel log messages about being unable to set a kprobe, which are both normal and benign, but have often freaked people out.