### PR TITLE
Fix a problem with subscribing to PROCESS_EVENT_TYPE_UPDATE events

### DIFF
--- a/examples/telemetry/main.go
+++ b/examples/telemetry/main.go
@@ -85,6 +85,9 @@ func createSubscription() *api.Subscription {
 		&api.ProcessEventFilter{
 			Type: api.ProcessEventType_PROCESS_EVENT_TYPE_EXIT,
 		},
+		&api.ProcessEventFilter{
+			Type: api.ProcessEventType_PROCESS_EVENT_TYPE_UPDATE,
+		},
 	}
 
 	syscallEvents := []*api.SyscallEventFilter{

--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -1306,9 +1306,9 @@ func registerProcessEvents(
 	events []*api.ProcessEventFilter,
 ) {
 	var (
-		filters       [4]*api.Expression
-		subscriptions [4]*eventSink
-		wildcards     [4]bool
+		filters       [5]*api.Expression
+		subscriptions [5]*eventSink
+		wildcards     [5]bool
 	)
 
 	for _, pef := range events {
@@ -1316,7 +1316,7 @@ func registerProcessEvents(
 		rewriteProcessEventFilter(pef)
 
 		t := pef.Type
-		if t < 1 || t > 3 {
+		if t < 1 || t > api.ProcessEventType(len(subscriptions)-1) {
 			subscr.logStatus(
 				code.Code_INVALID_ARGUMENT,
 				fmt.Sprintf("ProcessEventType %d is invalid", t))


### PR DESCRIPTION
When subscribing to `PROCESS_EVENT_TYPE_UPDATE` events, one of the checks to ensure the validity of the subscription was incorrect. I also added this event type to the telemetry example.