### PR TITLE
Set the ProcessID for a task existing when the sensor starts up

### DIFF
--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -675,6 +675,7 @@ func (pc *ProcessInfoCache) cacheTaskFromProc(tgid, pid int) error {
 	} else {
 		t.StartTime = sys.CurrentMonotonicRaw()
 	}
+	t.ProcessID = proc.DeriveUniqueID(t.PID, uint64(t.StartTime))
 	if t.PID != t.TGID {
 		t.parent = pc.cache.LookupTask(t.TGID)
 	} else {


### PR DESCRIPTION
During sensor startup, the `ProcessID` for each task found was not being set, leading to every pre-existing process having no `ProcessID` in any events they generate.