### PR TITLE
Add an example of a negative filter

### DIFF
--- a/examples/telemetry/main.go
+++ b/examples/telemetry/main.go
@@ -91,13 +91,27 @@ func createSubscription() *api.Subscription {
 	}
 
 	syscallEvents := []*api.SyscallEventFilter{
-		// Get all open(2) syscalls that return an error
+		// Get all open(2) syscalls
 		&api.SyscallEventFilter{
-			Type: api.SyscallEventType_SYSCALL_EVENT_TYPE_EXIT,
+			Type: api.SyscallEventType_SYSCALL_EVENT_TYPE_ENTER,
 
 			Id: &wrappers.Int64Value{
 				Value: 2, // SYS_OPEN
 			},
+		},
+
+		// An example of negative filters:
+		// Get all setuid(2) calls that are not root
+		&api.SyscallEventFilter{
+			Type: api.SyscallEventType_SYSCALL_EVENT_TYPE_ENTER,
+
+			Id: &wrappers.Int64Value{
+				Value: 105, // SYS_SETUID
+			},
+
+			FilterExpression: expression.NotEqual(
+				expression.Identifier("arg0"),
+				expression.Value(int64(0))),
 		},
 	}
 


### PR DESCRIPTION
Since the question has been asked: how do you write a negative filter? This PR adds an example of a negative filter.

There's also two additional code changes in here:
1. fix the comment for the syscall filter for sys_open. Given that it's not possible to write a filter to do what the comment previously said, change the filter from an EXIT to an ENTER type.
2. emit status information encoded in telemetry events. This is especially helpful for diagnosing subscription errors.