### PR TITLE
Add a command-line flag to print version information and exit

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,10 +16,41 @@
 package version
 
 import (
+	"flag"
 	"fmt"
+	"os"
 
 	"github.com/golang/glog"
 )
+
+type versionValue struct {
+}
+
+func (v versionValue) String() string {
+	var buildLog string
+	if Build != "" {
+		buildLog = fmt.Sprintf(" [%s]", Build)
+	}
+
+	return fmt.Sprintf("%s%s", Version, buildLog)
+}
+
+func (v versionValue) Set(s string) error {
+	fmt.Println(v.String())
+	os.Exit(0)
+
+	// unreachable
+	return nil
+}
+
+func (v versionValue) IsBoolFlag() bool {
+	return true
+}
+
+func init() {
+	var v versionValue
+	flag.Var(v, "version", "Print version information and exit")
+}
 
 var (
 	// Version is a SemVer 2.0 formatted version string


### PR DESCRIPTION
Any command that uses this `version` package will get a `-version` command-line flag that will print version information to `stdout` and exit immediately. It's kind of a hack, but the `flag` module doesn't really provide a good way to do this otherwise.