### PR TITLE
Make sure that ProcessEvent.fork_child_id gets set properly

### DIFF
--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -946,14 +946,16 @@ func (pc *ProcessInfoCache) handleSysClone(
 		changes["ContainerInfo"] = parentLeader.ContainerInfo
 	}
 
+	// This must be done before filling in eventData, because otherwise
+	// childTask.ProcessID won't be set yet.
+	childTask.parent = parentTask
+	childTask.Update(changes, sample.Time)
+
 	eventData := map[string]interface{}{
 		"__task__":       parentTask,
 		"fork_child_pid": int32(childTask.PID),
 		"fork_child_id":  childTask.ProcessID,
 	}
-
-	childTask.parent = parentTask
-	childTask.Update(changes, sample.Time)
 	pc.sensor.Monitor.EnqueueExternalSample(
 		pc.ProcessForkEventID,
 		sampleIDFromSample(sample),


### PR DESCRIPTION
Ordering is important! Make sure that the `childTask` struct gets updated before trying to use fields from it. The result of incorrect ordering was causing `fork_child_id` in `ProcessEvent` telemetry events to not be set properly.