### PR TITLE
Separate startup scans from cache/monitor instantiation

### DIFF
--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -177,15 +177,18 @@ func (s *Sensor) Start() error {
 
 	s.ContainerCache = NewContainerCache(s)
 	s.ProcessCache = NewProcessInfoCache(s)
+	s.ProcessCache.Start()
 
 	if len(config.Sensor.DockerContainerDir) > 0 {
 		s.dockerMonitor = newDockerMonitor(s,
 			config.Sensor.DockerContainerDir)
+		s.dockerMonitor.start()
 	}
 	/* Temporarily disable the OCI monitor until a better means of
 	   supporting it is found.
 	if len(config.Sensor.OciContainerDir) > 0 {
 		s.ociMonitor = newOciMonitor(s, config.Sensor.OciContainerDir)
+		s.ociMonitor.start()
 	}
 	*/
 


### PR DESCRIPTION
The process info cache, docker monitor, and oci monitor all follow the same pattern when they're instantiated to scan for existing objects while tracking changes during the scan. If process events occur during /proc scanning, processing the deferred updates will cause the sensor to panic because the sensor's ProcessCache pointer will be nil until after NewProcessInfoCache returns. The solution is to separate the startup scan with deferred event processing from the instantiation of the cache so that there is an opportunity to set the sensor's ProcessCache pointer before any deferred events are handled.

The problem addressed here is not actually an issue for the docker or oci monitors, but they've been updated for consistency since they both follow the same pattern as the process info cache.