### PR TITLE
Add missing nil check for systems without Docker installed

### DIFF
--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -182,7 +182,9 @@ func (s *Sensor) Start() error {
 	if len(config.Sensor.DockerContainerDir) > 0 {
 		s.dockerMonitor = newDockerMonitor(s,
 			config.Sensor.DockerContainerDir)
-		s.dockerMonitor.start()
+		if s.dockerMonitor != nil {
+			s.dockerMonitor.start()
+		}
 	}
 	/* Temporarily disable the OCI monitor until a better means of
 	   supporting it is found.


### PR DESCRIPTION
A recent change split the instantiation of the docker monitor instance from the scan of the filesystem for existing containers. If Docker is not installed, no docker monitor instance will be instantiated, thus returning `nil` from `newDockerMonitor`, which requires a `nil` check before calling its `start` function. This PR adds that missing `nil` check.