### PR TITLE
Update the sensor with changes required to support Linux 4.17 kernels

### DIFF
--- a/pkg/sensor/docker_monitor.go
+++ b/pkg/sensor/docker_monitor.go
@@ -65,11 +65,11 @@ type dockerConfigV2 struct {
 const (
 	dockerRenameKprobeSymbol    = "sys_renameat"
 	dockerRenameKprobeFetchargs = "newname=+0(%cx):string"
-	dockerRenameKprobeFilter    = "newname ~ */config.v2.json"
+	dockerRenameKprobeFilter    = "newname ~ \"*/config.v2.json\""
 
 	dockerUnlinkKprobeSymbol    = "sys_unlinkat"
 	dockerUnlinkKprobeFetchargs = "pathname=+0(%si):string"
-	dockerUnlinkKprobeFilter    = "pathname ~ */config.v2.json"
+	dockerUnlinkKprobeFilter    = "pathname ~ \"*/config.v2.json\""
 )
 
 type dockerDeferredAction func()

--- a/pkg/sensor/oci_monitor.go
+++ b/pkg/sensor/oci_monitor.go
@@ -46,7 +46,7 @@ type ociConfig struct {
 const (
 	ociSysOpenKprobeSymbol    = "do_sys_open"
 	ociSysOpenKprobeFetchargs = "filename=+0(%si):string flags=%dx:s32"
-	ociSysOpenKprobeFilter    = "(flags & 1 || flags & 2) && filename ~ */config.json"
+	ociSysOpenKprobeFilter    = "(flags & 1 || flags & 2) && filename ~ \"*/config.json\""
 
 	// It would be nice if we could also pull out file->dentry->d_parent->d_name
 	// here to get the parent filename, but testing yields no useful
@@ -55,13 +55,13 @@ const (
 	ociImaFileFreeKprobeFetchargs = "filename=+56(+24(%di)):string p=+56(+24(%di)):u64 " +
 		"f_op=+40(%di):u64 f_flags=+64(%di):u32 old_f_flags=+56(%di):u32"
 	// f_op will be NULL if f_inode is missing as in 2.6 kernels
-	ociImaFileFreeKprobeFilter = "p != 0 && filename == config.json " +
+	ociImaFileFreeKprobeFilter = "p != 0 && filename == \"config.json\" " +
 		"&& ((f_op == 0 && (old_f_flags & 1 || old_f_flags & 2)) || " +
 		"    (f_op != 0 && (f_flags & 1 || f_flags & 2)))"
 
 	ociUnlinkKprobeSymbol    = "sys_unlinkat"
 	ociUnlinkKprobeFetchargs = "pathname=+0(%si):string"
-	ociUnlinkKprobeFilter    = "pathname ~ */config.json"
+	ociUnlinkKprobeFilter    = "pathname ~ \"*/config.json\""
 )
 
 type ociDeferredAction func()

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -557,8 +557,27 @@ func (s *Sensor) IsKernelSymbolAvailable(symbol string) bool {
 	return ok
 }
 
+// Map for rewriting kprobe fetch args in kernel 4.17+
+// N.B. %di must come first to avoid replacing a %di in an already replaced
+// expression.
+// N.B. %cx actually needs to be replaced with pt_regs->r10. Since the syscall
+// handlers used to have "real" arguments, registers were setup according to the
+// x64 _C_ ABI, however now the syscalls only get a pointer to the register state
+// at the time the syscall entered, which means the registers are setup in the
+// x64 _syscall_ ABI.
+var fetchArgsReplacements = [][2]string{
+	{"%di", "+0x70(%di)"}, // pt_regs+0x70
+	{"%si", "+0x68(%di)"},
+	{"%dx", "+0x60(%di)"},
+	{"%cx", "+0x38(%di)"}, // This is actually replacing RCX with R10
+	{"%r8", "+0x48(%di)"},
+	{"%r9", "+0x40(%di)"},
+	{"%ax", "+0x50(%di)"},
+}
+
 // RegisterKprobe registers a kprobe with the sensor's EventMonitor instance,
-// but before doing so, ensures that the kernel symbol is available.
+// but before doing so, ensures that the kernel symbol is available and potentially
+// transforms it to account for new kernel changes.
 func (s *Sensor) RegisterKprobe(
 	address string,
 	onReturn bool,
@@ -573,14 +592,24 @@ func (s *Sensor) RegisterKprobe(
 				address = actual
 			}
 		} else {
-			// Linux 4.17 changes how syscall handlers are named, adding a `__x64_`
-			// prefix. Automatically try to prepend that if we're registering a
-			// kprobe on a syscall handler.
+			// Linux 4.17 changes how syscall handlers are done. It adds a `__x64_`
+			// prefix and also changes how arguments are handled in the syscall handler.
+			// Automatically try to prepend `__x64_` if we're registering a kprobe
+			// on a syscall handler, and if it succeeds, rewrite the kprobe fetch args.
 			if strings.HasPrefix(address, "sys_") {
 				actual, ok := s.kallsyms["__x64_"+address]
 				if ok {
 					glog.V(2).Infof("Using %q for kprobe symbol %q", actual, address)
 					address = actual
+
+					// rewrite `output` (the kprobe fetch args) to account for
+					// the only argument to the syscall handler being `pt_regs *regs`
+					for _, rewritePair := range fetchArgsReplacements {
+						srcReg := rewritePair[0]
+						dstExpr := rewritePair[1]
+						output = strings.Replace(output, srcReg, dstExpr, -1)
+					}
+					glog.V(2).Infof("Rewrote kprobe fetch args to %q", output)
 				} else {
 					return 0, fmt.Errorf("Kernel symbol not found: %s", address)
 				}

--- a/pkg/sys/proc/procfs/kernel.go
+++ b/pkg/sys/proc/procfs/kernel.go
@@ -49,7 +49,12 @@ func (fs *FileSystem) KernelTextSymbolNames() (map[string]string, error) {
 		// element unless both arguments are the empty string. No need
 		// to check len(parts) before using parts[0]
 		parts := strings.Split(fields[2], ".")
-		symbols[parts[0]] = fields[2]
+		_, exists := symbols[parts[0]]
+		// Add this as a symbol if no symbol already exists with name,
+		// or if this is an untouched symbol (i.e. no '.' in the name)
+		if !exists || len(parts) == 1 {
+			symbols[parts[0]] = fields[2]
+		}
 	}
 
 	return symbols, nil

--- a/scripts/system-check
+++ b/scripts/system-check
@@ -145,12 +145,12 @@ function lookup_kernel_symbol () {
             continue
         fi
         local sym="`echo ${line} | cut -d ' ' -f 3`"
-        if [ "${sym}" = "$1" ]; then
+        if [ "${sym}" = "$1" ] || [ "${sym}" = "__x64_$1" ]; then
             result="${sym}"
             break
         fi
         local sym2="`echo ${sym} | cut -d '.' -f 1`"
-        if [ "${sym2}" = "$1" ]; then
+        if [ "${sym2}" = "$1" ] || [ "${sym2}" = "__x64_$1" ]; then
             result="${sym}"
             break
         fi


### PR DESCRIPTION
As discovered in #225, Linux 4.17 changes the prefix on syscall handlers (so `sys_execve` is now `__x64_sys_execve`) and also changes how arguments are handled (now a single `pt_regs *regs` argument is the only thing passed to the C function). This PR changes the sensor to automatically try and register kprobes on functions with the new prefix if applicable, and also transforms the kprobe fetch args to account for the new way arguments are passed.