### PR TITLE
Remove do_execve Kprobe

### DIFF
--- a/pkg/sensor/process.go
+++ b/pkg/sensor/process.go
@@ -104,8 +104,6 @@ const (
 
 	execveArgCount = 6
 
-	doExecveAddress    = "do_execve"
-	doExecveArgs       = "filename=+0(+0(%di)):string "
 	doExecveatAddress  = "do_execveat"
 	doExecveatArgs     = "filename=+0(+0(%si)):string "
 	sysExecveAddress   = "sys_execve"
@@ -565,11 +563,6 @@ func NewProcessInfoCache(sensor *Sensor) *ProcessInfoCache {
 		glog.Fatalf("Couldn't register event %s: %s",
 			sysExecveAddress, err)
 	}
-	_, _ = sensor.RegisterKprobe(
-		doExecveAddress, false,
-		doExecveArgs+makeExecveFetchArgs("si"),
-		cache.decodeExecve,
-		perf.WithEventEnabled())
 
 	_, err = sensor.RegisterKprobe(
 		sysExecveatAddress, false,


### PR DESCRIPTION
This PR removes the kprobe on `do_execve` for 2 reasons:

1. There don't appear to be any cases where `do_execve` would be available to hook, while `sys_execve` wouldn't be.
2. Older kernels (pre https://github.com/torvalds/linux/commit/c4ad8f98bef77c7356aa6a9ad9188a6acc6b849d) have a different prototype for `do_execve` (the first argument is a `char*`, not a `struct filename*`), so this hook returns bad data on those kernels.